### PR TITLE
fix: use esm import for tailwind plugin

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,6 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        // Use ESM import to avoid CommonJS require in ESM environment
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- replace CommonJS require with ESM import in tailwind config

## Testing
- `npx eslint tailwind.config.ts`
- `npm run build`
- `npm run lint` *(fails: 129 problems (114 errors, 15 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689f384632748333bce7d1f4c9abf448