### PR TITLE
Restrict denuncias RLS to admins while keeping public reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Access control for denúncias
+
+The `denuncias` table in Supabase uses row-level security:
+
+- Anonymous users may submit new denúncias but cannot view, update or delete any entries.
+- Only authenticated users with the `administrador` role can read, update or delete existing denúncias.
+
+These policies ensure public reporting while keeping report data restricted to administrators.

--- a/supabase/migrations/20250815143000_eb435e44-d214-4d2e-9fcb-9edb8f2ac043.sql
+++ b/supabase/migrations/20250815143000_eb435e44-d214-4d2e-9fcb-9edb8f2ac043.sql
@@ -1,0 +1,26 @@
+-- Reintroduce restrictive policies for public.denuncias
+-- Drop open policies
+DROP POLICY IF EXISTS "Open access to view denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to insert denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to update denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to delete denuncias" ON public.denuncias;
+
+-- Allow public reporting via anonymous insert
+CREATE POLICY "Public can insert denuncias" ON public.denuncias
+  FOR INSERT TO anon, authenticated
+  WITH CHECK (true);
+
+-- Restrict viewing to administrators
+CREATE POLICY "Admin can view denuncias" ON public.denuncias
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(), 'administrador'));
+
+-- Restrict updates to administrators
+CREATE POLICY "Admin can update denuncias" ON public.denuncias
+  FOR UPDATE TO authenticated
+  USING (public.has_role(auth.uid(), 'administrador'));
+
+-- Restrict deletes to administrators
+CREATE POLICY "Admin can delete denuncias" ON public.denuncias
+  FOR DELETE TO authenticated
+  USING (public.has_role(auth.uid(), 'administrador'));


### PR DESCRIPTION
## Summary
- replace open `denuncias` policies with administrator-only read/update/delete and allow anonymous inserts
- document new denuncias access controls in README

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- Attempted `npm install -g supabase` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f4329375083339c3126b2f6279d01