### PR TITLE
Integrate denuncias with Supabase

### DIFF
--- a/src/components/hr/DenunciasEmpresa.tsx
+++ b/src/components/hr/DenunciasEmpresa.tsx
@@ -118,27 +118,27 @@ export function DenunciasEmpresa({ empresaId }: DenunciasEmpresaProps) {
     OUTRO: 'Outro'
   };
 
-  const handleAtualizarStatus = () => {
+  const handleAtualizarStatus = async () => {
     if (!selectedDenuncia) return;
-    
-    atualizarStatus(selectedDenuncia.id, novoStatus);
+
+    await atualizarStatus(selectedDenuncia.id, novoStatus);
     setSelectedDenuncia({ ...selectedDenuncia, status: novoStatus });
-    
+
     toast({
       title: 'Status atualizado',
       description: `Denúncia ${selectedDenuncia.protocolo} foi marcada como ${statusLabels[novoStatus].toLowerCase()}.`
     });
   };
 
-  const handleAdicionarComentario = () => {
+  const handleAdicionarComentario = async () => {
     if (!selectedDenuncia || !novoComentario.trim()) return;
-    
-    adicionarComentario(selectedDenuncia.id, { autor: 'Sistema', mensagem: novoComentario });
+
+    await adicionarComentario(selectedDenuncia.id, { autor: 'Sistema', mensagem: novoComentario });
     setNovoComentario('');
-    
+
     // Atualizar denúncia local
-    const updatedDenuncia = { 
-      ...selectedDenuncia, 
+    const updatedDenuncia = {
+      ...selectedDenuncia,
       comentarios: [...selectedDenuncia.comentarios, {
         id: Date.now().toString(),
         denunciaId: selectedDenuncia.id,
@@ -148,7 +148,7 @@ export function DenunciasEmpresa({ empresaId }: DenunciasEmpresaProps) {
       }]
     };
     setSelectedDenuncia(updatedDenuncia);
-    
+
     toast({
       title: 'Comentário adicionado',
       description: 'Seu comentário foi registrado na denúncia.'

--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -89,6 +89,16 @@ export type Denuncia = {
   status: 'RECEBIDO' | 'EM_ANALISE' | 'INVESTIGACAO' | 'CONCLUIDO';
   created_at: string;
   updated_at: string;
+  comentarios_denuncia?: ComentarioDenuncia[];
+};
+
+export type ComentarioDenuncia = {
+  id: string;
+  denuncia_id: string;
+  autor: string;
+  mensagem: string;
+  created_at: string;
+  updated_at: string;
 };
 
 export const useSupabaseData = () => {
@@ -137,25 +147,24 @@ export const useSupabaseData = () => {
     }
   };
 
-  const fetchDenuncias = async () => {
-    
-    try {
-      const { data, error } = await supabase
-        .from('denuncias')
-        .select('*')
-        .order('created_at', { ascending: false });
+    const fetchDenuncias = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('denuncias')
+          .select('*, comentarios_denuncia(*)')
+          .order('created_at', { ascending: false });
 
-      if (error) throw error;
-      setDenuncias(data || []);
-    } catch (error) {
-      console.error('Error fetching denuncias:', error);
-      toast({
-        title: "Erro ao carregar denúncias",
-        description: "Não foi possível carregar a lista de denúncias.",
-        variant: "destructive"
-      });
-    }
-  };
+        if (error) throw error;
+        setDenuncias(data || []);
+      } catch (error) {
+        console.error('Error fetching denuncias:', error);
+        toast({
+          title: "Erro ao carregar denúncias",
+          description: "Não foi possível carregar a lista de denúncias.",
+          variant: "destructive"
+        });
+      }
+    };
 
   // CRUD operations for empresas
   const adicionarEmpresa = async (empresa: Omit<Empresa, 'id' | 'created_at' | 'updated_at' | 'created_by'>) => {

--- a/src/pages/DenunciaPublica.tsx
+++ b/src/pages/DenunciaPublica.tsx
@@ -104,53 +104,29 @@ export default function DenunciaPublica() {
     }
 
     try {
-      const payload = {
-        empresa_id: empresaId,
+      const denuncia = await criarDenuncia({
+        empresaId: empresaId!,
         identificado: formData.identificado,
-        nome: formData.identificado ? formData.nome : null,
-        email: formData.identificado ? formData.email : null,
+        nome: formData.identificado ? formData.nome : undefined,
+        email: formData.identificado ? formData.email : undefined,
         relacao: formData.relacao as any,
         tipo: formData.tipo as any,
-        setor: formData.setor || null,
-        conhecimento_fato: formData.conhecimentoFato as any,
-        envolvidos_cientes: formData.envolvidosCientes,
+        setor: formData.setor || undefined,
+        conhecimentoFato: formData.conhecimentoFato as any,
+        envolvidosCientes: formData.envolvidosCientes,
         descricao: formData.descricao,
-        evidencias_descricao: formData.evidenciasDescricao || null,
-        sugestao: formData.sugestao || null,
-      };
+        evidenciasDescricao: formData.evidenciasDescricao || undefined,
+        sugestao: formData.sugestao || undefined,
+      });
 
-      const { data, error } = await supabase
-        .from('denuncias')
-        .insert(payload)
-        .select('protocolo')
-        .single();
+      if (!denuncia) throw new Error('Falha ao criar denúncia');
 
-      if (error) throw error;
-
-      // Atualiza painel interno (HRContext) para aparecer nos dashboards
-      try {
-        criarDenuncia({
-          empresaId: empresaId!,
-          identificado: formData.identificado,
-          nome: formData.identificado ? formData.nome : undefined,
-          email: formData.identificado ? formData.email : undefined,
-          relacao: formData.relacao as any,
-          tipo: formData.tipo as any,
-          setor: formData.setor || undefined,
-          conhecimentoFato: formData.conhecimentoFato as any,
-          envolvidosCientes: formData.envolvidosCientes,
-          descricao: formData.descricao,
-          evidenciasDescricao: formData.evidenciasDescricao || undefined,
-          sugestao: formData.sugestao || undefined,
-        });
-      } catch {}
-
-      setProtocolo((data as any).protocolo);
+      setProtocolo(denuncia.protocolo);
       setSubmitted(true);
-      
+
       toast({
         title: 'Denúncia registrada',
-        description: `Protocolo ${(data as any).protocolo} gerado com sucesso.`
+        description: `Protocolo ${denuncia.protocolo} gerado com sucesso.`
       });
     } catch (error) {
       console.error('Erro ao registrar denúncia:', error);

--- a/src/pages/DenunciasDashboard.tsx
+++ b/src/pages/DenunciasDashboard.tsx
@@ -51,26 +51,26 @@ export default function DenunciasDashboard() {
     OUTRO: 'Outro'
   };
 
-  const handleAtualizarStatus = () => {
+  const handleAtualizarStatus = async () => {
     if (!selectedDenuncia) return;
-    
-    atualizarStatus(selectedDenuncia.id, novoStatus);
+
+    await atualizarStatus(selectedDenuncia.id, novoStatus);
     setSelectedDenuncia({ ...selectedDenuncia, status: novoStatus });
-    
+
     toast({
       title: 'Status atualizado',
       description: `Denúncia ${selectedDenuncia.protocolo} foi marcada como ${statusLabels[novoStatus].toLowerCase()}.`
     });
   };
 
-  const handleAdicionarComentario = () => {
+  const handleAdicionarComentario = async () => {
     if (!selectedDenuncia || !novoComentario.trim()) return;
-    
-    adicionarComentario(selectedDenuncia.id, { autor: 'Administrador', mensagem: novoComentario });
+
+    await adicionarComentario(selectedDenuncia.id, { autor: 'Administrador', mensagem: novoComentario });
     setNovoComentario('');
-    
-    const updatedDenuncia = { 
-      ...selectedDenuncia, 
+
+    const updatedDenuncia = {
+      ...selectedDenuncia,
       comentarios: [...selectedDenuncia.comentarios, {
         id: Date.now().toString(),
         denunciaId: selectedDenuncia.id,
@@ -80,7 +80,7 @@ export default function DenunciasDashboard() {
       }]
     };
     setSelectedDenuncia(updatedDenuncia);
-    
+
     toast({
       title: 'Comentário adicionado',
       description: 'Seu comentário foi registrado na denúncia.'

--- a/src/pages/admin/SystemData.tsx
+++ b/src/pages/admin/SystemData.tsx
@@ -124,12 +124,9 @@ const SystemData: React.FC = () => {
         evidencias_descricao: 'Evidências de exemplo.',
         sugestao: 'Tomar providências cabíveis.'
       }));
-      const { error: denErr } = await supabase.from('denuncias').insert(denunciasPayload);
-      if (denErr) throw denErr;
 
-      // Atualizar dashboards locais
-      denunciasPayload.forEach(d => {
-        criarDenuncia({
+      for (const d of denunciasPayload) {
+        await criarDenuncia({
           empresaId: (empresa as any).id,
           identificado: d.identificado,
           nome: d.nome,
@@ -141,9 +138,9 @@ const SystemData: React.FC = () => {
           envolvidosCientes: d.envolvidos_cientes,
           descricao: d.descricao,
           evidenciasDescricao: d.evidencias_descricao,
-          sugestao: d.sugestao
+          sugestao: d.sugestao,
         });
-      });
+      }
 
       // 4) Auditoria (localStorage)
       const itens = Array.from({ length: 12 }).map((_, i) => ({


### PR DESCRIPTION
## Summary
- Load denuncias from Supabase and expose CRUD helpers
- Replace mock denuncia handlers with Supabase implementations
- Update denuncia-related components to use async HR context operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f555982308333a166c293cfbd630d