### PR TITLE
Allow empresarial users to view denuncias

### DIFF
--- a/supabase/migrations/20250815120000_fix_rls_policies.sql
+++ b/supabase/migrations/20250815120000_fix_rls_policies.sql
@@ -9,7 +9,7 @@ DROP POLICY IF EXISTS "Open access to delete denuncias" ON public.denuncias;
 -- Restore restricted policies for denuncias
 CREATE POLICY "Admin can view denuncias" ON public.denuncias
   FOR SELECT TO authenticated
-  USING (public.has_role(auth.uid(), 'administrador'));
+  USING (public.has_role(auth.uid(), 'administrador') OR public.has_role(auth.uid(), 'empresarial'));
 
 CREATE POLICY "Anyone can insert denuncias" ON public.denuncias
   FOR INSERT TO anon, authenticated

--- a/supabase/migrations/20250815143000_eb435e44-d214-4d2e-9fcb-9edb8f2ac043.sql
+++ b/supabase/migrations/20250815143000_eb435e44-d214-4d2e-9fcb-9edb8f2ac043.sql
@@ -13,7 +13,7 @@ CREATE POLICY "Public can insert denuncias" ON public.denuncias
 -- Restrict viewing to administrators
 CREATE POLICY "Admin can view denuncias" ON public.denuncias
   FOR SELECT TO authenticated
-  USING (public.has_role(auth.uid(), 'administrador'));
+  USING (public.has_role(auth.uid(), 'administrador') OR public.has_role(auth.uid(), 'empresarial'));
 
 -- Restrict updates to administrators
 CREATE POLICY "Admin can update denuncias" ON public.denuncias

--- a/supabase/migrations/20250815160000_restrict_denuncias_policies.sql
+++ b/supabase/migrations/20250815160000_restrict_denuncias_policies.sql
@@ -15,7 +15,7 @@ CREATE POLICY "Public can insert denuncias" ON public.denuncias
 -- Restrict viewing to administrators
 CREATE POLICY "Admin can view denuncias" ON public.denuncias
   FOR SELECT TO authenticated
-  USING (public.has_role(auth.uid(), 'administrador'));
+  USING (public.has_role(auth.uid(), 'administrador') OR public.has_role(auth.uid(), 'empresarial'));
 
 -- Restrict updates to administrators
 CREATE POLICY "Admin can update denuncias" ON public.denuncias


### PR DESCRIPTION
## Summary
- Allow `empresarial` users to view `denuncias` by extending RLS policy in migrations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npx supabase db reset` *(fails: 403 Forbidden downloading supabase CLI)*

------
https://chatgpt.com/codex/tasks/task_e_689f57696d948333ae666a9d66cf43f9