### PR TITLE
Tighten devedores RLS policies

### DIFF
--- a/supabase/migrations/20250819180000_tighten_devedores_rls.sql
+++ b/supabase/migrations/20250819180000_tighten_devedores_rls.sql
@@ -1,0 +1,27 @@
+-- Tighten RLS policies for devedores table
+DROP POLICY IF EXISTS "Users can view devedores based on role" ON public.devedores;
+
+CREATE POLICY "Users can view devedores based on role"
+  ON public.devedores
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'operacional'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can manage devedores" ON public.devedores;
+CREATE POLICY "Admins can manage devedores"
+  ON public.devedores
+  FOR INSERT, UPDATE, DELETE
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND has_role(auth.uid(), 'administrador'::user_role)
+  )
+  WITH CHECK (
+    user_can_access_empresa(empresa_id)
+    AND has_role(auth.uid(), 'administrador'::user_role)
+  );


### PR DESCRIPTION
## Summary
- add migration tightening `devedores` table RLS
- require empresa access and operational/administrator roles for SELECT
- restrict INSERT/UPDATE/DELETE to administrators

## Testing
- `npm run lint` *(fails: Unexpected any, etc)*
- `npm test` *(fails: Missing script "test")*
- `npx supabase --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f67755b788333a2ab190712101c88