### PR TITLE
Harden denuncias RLS

### DIFF
--- a/supabase/migrations/20250819170000_harden_denuncias_rls.sql
+++ b/supabase/migrations/20250819170000_harden_denuncias_rls.sql
@@ -1,0 +1,44 @@
+-- Harden RLS policies for public.denuncias
+DROP POLICY IF EXISTS "Anyone can insert denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admins can view denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admins can update denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admins can delete denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Public can insert denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admin can view denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admin can update denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admin can delete denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to view denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to insert denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to update denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Open access to delete denuncias" ON public.denuncias;
+
+ALTER TABLE public.denuncias ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can insert denuncias" ON public.denuncias
+  FOR INSERT TO anon, authenticated
+  WITH CHECK (true);
+
+CREATE POLICY "Admins can view company denuncias" ON public.denuncias
+  FOR SELECT TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'administrador') AND
+    user_can_access_empresa(empresa_id)
+  );
+
+CREATE POLICY "Admins can update company denuncias" ON public.denuncias
+  FOR UPDATE TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'administrador') AND
+    user_can_access_empresa(empresa_id)
+  )
+  WITH CHECK (
+    public.has_role(auth.uid(), 'administrador') AND
+    user_can_access_empresa(empresa_id)
+  );
+
+CREATE POLICY "Admins can delete company denuncias" ON public.denuncias
+  FOR DELETE TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'administrador') AND
+    user_can_access_empresa(empresa_id)
+  );


### PR DESCRIPTION
## Summary
- drop prior `denuncias` policies and enable RLS
- require admins with empresa access for `SELECT`, `UPDATE`, and `DELETE`
- preserve anonymous `INSERT` capability

## Testing
- `npm run lint` *(fails: Unexpected any, exhaustively deps, etc.)*
- `npm install -g supabase` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f6770b0b48333a4263a1fe95fad30