### PR TITLE
Restrict historico_colaborador policies to HR and managers

### DIFF
--- a/supabase/migrations/20250819220000_restrict_historico_colaborador.sql
+++ b/supabase/migrations/20250819220000_restrict_historico_colaborador.sql
@@ -1,0 +1,13 @@
+DROP POLICY IF EXISTS "Users can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Authenticated users can insert history" ON public.historico_colaborador;
+
+CREATE POLICY "HR or managers can view history" ON public.historico_colaborador
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(), 'administrador') OR public.has_role(auth.uid(), 'empresarial'));
+
+CREATE POLICY "HR or managers can insert history" ON public.historico_colaborador
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (public.has_role(auth.uid(), 'administrador') OR public.has_role(auth.uid(), 'empresarial'))
+    AND auth.uid() = created_by
+  );


### PR DESCRIPTION
## Summary
- drop existing historico_colaborador RLS policies
- allow only HR or managers to select/insert historico_colaborador records

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx supabase db reset` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `psql postgres://postgres:postgres@localhost:5432/postgres -c "select 1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ded4ccc8333a1dfb9fb3d826a5f