### PR TITLE
feat: allow cobranca role to view devedores

### DIFF
--- a/supabase/migrations/20250820190000_add_cobranca_role_to_devedores.sql
+++ b/supabase/migrations/20250820190000_add_cobranca_role_to_devedores.sql
@@ -1,0 +1,29 @@
+-- Allow cobranca role to view devedores
+DROP POLICY IF EXISTS "Users can view devedores based on role" ON public.devedores;
+
+CREATE POLICY "Users can view devedores based on role"
+  ON public.devedores
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'operacional'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+      OR has_role(auth.uid(), 'cobranca'::user_role)
+    )
+  );
+
+-- Ensure DML operations remain restricted to admins
+DROP POLICY IF EXISTS "Admins can manage devedores" ON public.devedores;
+CREATE POLICY "Admins can manage devedores"
+  ON public.devedores
+  FOR INSERT, UPDATE, DELETE
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND has_role(auth.uid(), 'administrador'::user_role)
+  )
+  WITH CHECK (
+    user_can_access_empresa(empresa_id)
+    AND has_role(auth.uid(), 'administrador'::user_role)
+  );


### PR DESCRIPTION
## Summary
- allow `cobranca` role to view `devedores`
- reaffirm admin-only insert/update/delete policies for `devedores`

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689f81be34d88333b3ef29fee77cf45c