### PR TITLE
Restrict documentos_divida policies

### DIFF
--- a/supabase/migrations/20250820120000_restrict_documentos_divida_policies.sql
+++ b/supabase/migrations/20250820120000_restrict_documentos_divida_policies.sql
@@ -1,0 +1,16 @@
+-- Tighten policies for documentos_divida to allow only admins or uploader
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "Users can view documentos based on empresa access" ON public.documentos_divida;
+DROP POLICY IF EXISTS "Admins can manage documentos" ON public.documentos_divida;
+
+-- Allow uploader or administrators to view documents
+CREATE POLICY "Uploader or admin can view documentos_divida" ON public.documentos_divida
+  FOR SELECT TO authenticated
+  USING (uploaded_by = auth.uid() OR public.has_role(auth.uid(), 'administrador'));
+
+-- Restrict all modifications to administrators
+CREATE POLICY "Admin can manage documentos_divida" ON public.documentos_divida
+  FOR ALL TO authenticated
+  USING (public.has_role(auth.uid(), 'administrador'))
+  WITH CHECK (public.has_role(auth.uid(), 'administrador'));


### PR DESCRIPTION
## Summary
- enforce documentos_divida visibility to uploader or admins only
- restrict all documentos_divida modifications to administrators

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 217 problems (201 errors, 16 warnings))*
- `npm install -g supabase` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*

------
https://chatgpt.com/codex/tasks/task_e_689f81c0275c8333ba6fa0fa684b84fe