### PR TITLE
Restrict historico_colaborador policies

### DIFF
--- a/supabase/migrations/20250820120000_update_historico_colaborador_policies.sql
+++ b/supabase/migrations/20250820120000_update_historico_colaborador_policies.sql
@@ -1,0 +1,23 @@
+-- Tighten historico_colaborador policies: restrict open access
+DROP POLICY IF EXISTS "Users can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Authenticated users can insert history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "HR or managers can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "HR or managers can insert history" ON public.historico_colaborador;
+
+CREATE POLICY "Admins, business or managers can view history" ON public.historico_colaborador
+  FOR SELECT TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'administrador') OR
+    public.has_role(auth.uid(), 'empresarial') OR
+    EXISTS (
+      SELECT 1 FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+      AND c.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Only HR can insert history" ON public.historico_colaborador
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.has_role(auth.uid(), 'rh') AND auth.uid() = created_by
+  );


### PR DESCRIPTION
## Summary
- tighten historico_colaborador RLS, allowing select only for admins, empresarial role or the collaborator's creator
- limit history inserts to HR users only

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 217 problems (201 errors, 16 warnings))*
- `npx supabase db reset` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f81c2ced88333be2edefc995de544