### PR TITLE
Configura expiração de OTP no Supabase

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,4 @@
 project_id = "pxpscjyeqmqqxzbttbep"
+
+[auth.otp]
+expiry_duration = "60s"  # valor conforme política interna


### PR DESCRIPTION
## Summary
- define duração de expiração de OTP para 60s na configuração do Supabase

## Testing
- `npx supabase stop` *(falha: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `npx supabase start` *(falha: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `npm test` *(falha: Missing script: "test")*
- `npm run lint` *(falha: Unexpected any, React Hook warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f81c4179c83339bf6b679a3b398dc