### PR TITLE
chore: enforce public search path for security-definer functions

### DIFF
--- a/supabase/migrations/20250808173652_d8fecc0c-3781-4263-bc7f-bd8643a9072a.sql
+++ b/supabase/migrations/20250808173652_d8fecc0c-3781-4263-bc7f-bd8643a9072a.sql
@@ -179,6 +179,7 @@ RETURNS public.user_role
 LANGUAGE SQL
 STABLE
 SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT role FROM public.profiles WHERE user_id = user_uuid;
 $$;
@@ -189,6 +190,7 @@ RETURNS BOOLEAN
 LANGUAGE SQL
 STABLE
 SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT EXISTS (
     SELECT 1 FROM public.profiles 
@@ -322,7 +324,7 @@ CREATE TRIGGER update_denuncias_updated_at
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER
 LANGUAGE plpgsql
-SECURITY DEFINER SET search_path = ''
+SECURITY DEFINER SET search_path = public
 AS $$
 BEGIN
   INSERT INTO public.profiles (user_id, username, role)

--- a/supabase/migrations/20250808174016_ca70201f-f8f2-42d2-9c70-1d18d2d7691c.sql
+++ b/supabase/migrations/20250808174016_ca70201f-f8f2-42d2-9c70-1d18d2d7691c.sql
@@ -179,6 +179,7 @@ RETURNS public.user_role
 LANGUAGE SQL
 STABLE
 SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT role FROM public.profiles WHERE user_id = user_uuid;
 $$;
@@ -189,6 +190,7 @@ RETURNS BOOLEAN
 LANGUAGE SQL
 STABLE
 SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT EXISTS (
     SELECT 1 FROM public.profiles 
@@ -332,7 +334,7 @@ CREATE TRIGGER update_denuncias_updated_at
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER
 LANGUAGE plpgsql
-SECURITY DEFINER SET search_path = ''
+SECURITY DEFINER SET search_path = public
 AS $$
 BEGIN
   INSERT INTO public.profiles (user_id, username, role)

--- a/supabase/migrations/20250808184558_d54f6851-b3fb-440d-8cd4-786190e9cdb1.sql
+++ b/supabase/migrations/20250808184558_d54f6851-b3fb-440d-8cd4-786190e9cdb1.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path TO ''
+SET search_path = public
 AS $function$
 BEGIN
   INSERT INTO public.profiles (user_id, username, role)

--- a/supabase/migrations/20250808191035_4086a6b5-660e-4ee4-b78e-1f33f3f78337.sql
+++ b/supabase/migrations/20250808191035_4086a6b5-660e-4ee4-b78e-1f33f3f78337.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path TO ''
+SET search_path = public
 AS $function$
 BEGIN
   INSERT INTO public.profiles (user_id, username, role)

--- a/supabase/migrations/20250808191051_e4fbc641-8d7c-4968-94c6-0136b553ed31.sql
+++ b/supabase/migrations/20250808191051_e4fbc641-8d7c-4968-94c6-0136b553ed31.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path TO ''
+SET search_path = public
 AS $function$
 BEGIN
   INSERT INTO public.profiles (user_id, username, role)

--- a/supabase/migrations/20250808195901_a7e057e0-0c06-408e-91b6-660ee2d6339d.sql
+++ b/supabase/migrations/20250808195901_a7e057e0-0c06-408e-91b6-660ee2d6339d.sql
@@ -13,7 +13,7 @@ ADD COLUMN IF NOT EXISTS last_login timestamp with time zone;
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS trigger
 LANGUAGE plpgsql
-SECURITY DEFINER SET search_path = ''
+SECURITY DEFINER SET search_path = public
 AS $$
 BEGIN
   INSERT INTO public.profiles (user_id, username, full_name, role)
@@ -64,6 +64,7 @@ CREATE OR REPLACE FUNCTION public.update_last_login()
 RETURNS void
 LANGUAGE sql
 SECURITY DEFINER
+SET search_path = public
 AS $$
   UPDATE public.profiles 
   SET last_login = now() 

--- a/supabase/migrations/20250808202730_bcb604b0-1bd9-443d-8ddd-095bde095672.sql
+++ b/supabase/migrations/20250808202730_bcb604b0-1bd9-443d-8ddd-095bde095672.sql
@@ -7,6 +7,7 @@ CREATE OR REPLACE FUNCTION public.authenticate_by_username(username_input text, 
 RETURNS TABLE(user_id uuid, email text)
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public
 AS $$
 DECLARE
   user_email text;

--- a/supabase/migrations/20250808203602_31cb8bb1-cdad-4723-b222-a7e793bfdb82.sql
+++ b/supabase/migrations/20250808203602_31cb8bb1-cdad-4723-b222-a7e793bfdb82.sql
@@ -11,6 +11,7 @@ CREATE OR REPLACE FUNCTION public.authenticate_by_username(username_input text, 
 RETURNS TABLE(user_id uuid, email text)
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public
 AS $$
 DECLARE
   user_email text;

--- a/supabase/migrations/20250813121644_1ecb65cc-52f8-4f8a-9482-c391831e3375.sql
+++ b/supabase/migrations/20250813121644_1ecb65cc-52f8-4f8a-9482-c391831e3375.sql
@@ -65,6 +65,7 @@ CREATE OR REPLACE FUNCTION public.user_can_access_empresa(empresa_uuid uuid)
 RETURNS boolean
 LANGUAGE sql
 STABLE SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT 
     has_role(auth.uid(), 'superuser'::user_role) OR

--- a/supabase/migrations/20250813121915_1319f20b-4da5-4f0b-a966-93bfc50c4b14.sql
+++ b/supabase/migrations/20250813121915_1319f20b-4da5-4f0b-a966-93bfc50c4b14.sql
@@ -94,6 +94,7 @@ CREATE OR REPLACE FUNCTION public.user_can_access_empresa_data(empresa_uuid uuid
 RETURNS boolean
 LANGUAGE sql
 STABLE SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT 
     -- Superusers e administradores têm acesso total

--- a/supabase/migrations/20250815170015_bedd4112-9133-44e6-a593-d5fb0a4dcb8f.sql
+++ b/supabase/migrations/20250815170015_bedd4112-9133-44e6-a593-d5fb0a4dcb8f.sql
@@ -251,19 +251,18 @@ USING (
 CREATE OR REPLACE FUNCTION public.user_can_access_empresa(empresa_id_param uuid)
 RETURNS boolean AS $$
 BEGIN
-  SET search_path = '';
   RETURN EXISTS (
     SELECT 1 FROM public.profiles
     WHERE user_id = auth.uid() 
     AND (role = 'administrador' OR role = 'superuser' OR public.profiles.empresa_id = empresa_id_param)
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
 
 CREATE OR REPLACE FUNCTION public.user_can_access_empresa_data()
 RETURNS uuid AS $$
 BEGIN
-  SET search_path = '';
   RETURN (
     SELECT empresa_id FROM public.profiles
     WHERE user_id = auth.uid() 
@@ -272,33 +271,34 @@ BEGIN
     LIMIT 1
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
 
 CREATE OR REPLACE FUNCTION public.get_user_role()
 RETURNS TEXT AS $$
 BEGIN
-  SET search_path = '';
   RETURN (SELECT role FROM public.profiles WHERE user_id = auth.uid());
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
 
 CREATE OR REPLACE FUNCTION public.has_role(required_role TEXT)
 RETURNS boolean AS $$
 BEGIN
-  SET search_path = '';
   RETURN EXISTS (
     SELECT 1 FROM public.profiles 
     WHERE user_id = auth.uid() 
     AND role = required_role
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
 
 CREATE OR REPLACE FUNCTION public.update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
-  SET search_path = '';
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public;

--- a/supabase/migrations/20250815184722_06aa4213-8599-4142-b907-091a75b46ffc.sql
+++ b/supabase/migrations/20250815184722_06aa4213-8599-4142-b907-091a75b46ffc.sql
@@ -76,7 +76,7 @@ BEGIN
   RETURN COALESCE(NEW, OLD);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER
-SET search_path = '';
+SET search_path = public;
 
 -- Create trigger for audit logging
 DROP TRIGGER IF EXISTS trigger_log_denuncia_access ON public.denuncias;

--- a/supabase/migrations/20250817120000_update_user_can_access_empresa.sql
+++ b/supabase/migrations/20250817120000_update_user_can_access_empresa.sql
@@ -5,6 +5,7 @@ CREATE OR REPLACE FUNCTION public.user_can_access_empresa(empresa_uuid uuid)
 RETURNS boolean
 LANGUAGE sql
 STABLE SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT
     has_role(auth.uid(), 'superuser'::user_role) OR
@@ -35,3 +36,4 @@ CREATE POLICY "Admins can manage devedores"
     user_can_access_empresa(empresa_id) AND
     has_role(auth.uid(), 'administrador'::user_role)
   );
+

--- a/supabase/migrations/20250819170000_restrict_financial_tables.sql
+++ b/supabase/migrations/20250819170000_restrict_financial_tables.sql
@@ -8,6 +8,7 @@ RETURNS BOOLEAN
 LANGUAGE SQL
 STABLE
 SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT EXISTS (
     SELECT 1 FROM public.profiles
@@ -127,3 +128,4 @@ CREATE POLICY "Manage pagamentos with finance roles" ON public.pagamentos
       has_role(auth.uid(), 'financeiro_master'::user_role)
     )
   );
+

--- a/supabase/migrations/20250820120000_set_search_path_public.sql
+++ b/supabase/migrations/20250820120000_set_search_path_public.sql
@@ -1,0 +1,214 @@
+-- Recreate security definer functions with explicit search path
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (user_id, username, full_name, role)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data ->> 'username', NEW.email),
+    COALESCE(NEW.raw_user_meta_data ->> 'full_name', NEW.email),
+    'operacional'::public.user_role
+  );
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.log_denuncia_access()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.activity_logs (action, by_user, meta)
+  VALUES (
+    'denuncia_' || TG_OP,
+    COALESCE(auth.jwt() ->> 'email', 'anonymous'),
+    jsonb_build_object(
+      'denuncia_id', COALESCE(NEW.id, OLD.id),
+      'protocolo', COALESCE(NEW.protocolo, OLD.protocolo),
+      'timestamp', now()
+    )
+  );
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.user_can_access_empresa(empresa_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    has_role(auth.uid(), 'superuser'::user_role) OR
+    has_role(auth.uid(), 'administrador'::user_role) OR
+    (
+      has_role(auth.uid(), 'operacional'::user_role) AND
+      empresa_uuid = ANY (
+        SELECT unnest(empresa_ids)
+        FROM public.profiles
+        WHERE user_id = auth.uid()
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_can_access_empresa_data()
+RETURNS uuid AS $$
+BEGIN
+  RETURN (
+    SELECT empresa_id FROM public.profiles
+    WHERE user_id = auth.uid()
+    AND role != 'administrador'
+    AND role != 'superuser'
+    LIMIT 1
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.user_can_access_empresa_data(empresa_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    -- Superusers e administradores têm acesso total
+    has_role(auth.uid(), 'superuser'::user_role) OR
+    has_role(auth.uid(), 'administrador'::user_role) OR
+    -- Usuários empresariais só acessam suas empresas
+    (
+      has_role(auth.uid(), 'empresarial'::user_role) AND
+      empresa_uuid = ANY(
+        SELECT unnest(empresa_ids)
+        FROM public.profiles
+        WHERE user_id = auth.uid()
+      )
+    ) OR
+    -- Usuários operacionais acessam empresas onde trabalham
+    (
+      has_role(auth.uid(), 'operacional'::user_role) AND
+      EXISTS (
+        SELECT 1
+        FROM public.colaboradores
+        WHERE empresa_id = empresa_uuid
+        AND (created_by = auth.uid() OR updated_at IS NOT NULL)
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_user_role()
+RETURNS TEXT AS $$
+BEGIN
+  RETURN (SELECT role FROM public.profiles WHERE user_id = auth.uid());
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.has_role(required_role TEXT)
+RETURNS boolean AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE user_id = auth.uid()
+    AND role = required_role
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.has_role(user_uuid UUID, required_role public.user_role)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE user_id = user_uuid
+    AND (
+      role = required_role
+      OR role = 'superuser'
+      OR (required_role = 'operacional' AND role IN ('empresarial', 'administrador', 'financeiro', 'financeiro_master'))
+      OR (required_role = 'empresarial' AND role IN ('administrador', 'financeiro_master'))
+      OR (required_role = 'financeiro' AND role = 'financeiro_master')
+    )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.update_last_login()
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE public.profiles
+  SET last_login = now()
+  WHERE user_id = auth.uid();
+$$;
+
+CREATE OR REPLACE FUNCTION public.authenticate_by_username(username_input text, password_input text)
+RETURNS TABLE(user_id uuid, email text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_email text;
+  user_uuid uuid;
+BEGIN
+  -- Buscar por username primeiro
+  SELECT auth.users.email, auth.users.id
+  INTO user_email, user_uuid
+  FROM public.profiles
+  JOIN auth.users ON auth.users.id = profiles.user_id
+  WHERE profiles.username = username_input
+    AND profiles.is_active = true;
+
+  -- Se não encontrou por username, tentar por email
+  IF user_email IS NULL THEN
+    SELECT auth.users.email, auth.users.id
+    INTO user_email, user_uuid
+    FROM public.profiles
+    JOIN auth.users ON auth.users.id = profiles.user_id
+    WHERE auth.users.email = username_input
+      AND profiles.is_active = true;
+  END IF;
+
+  -- Se ainda não encontrou, verificar se existe na tabela auth mas não na profiles
+  IF user_email IS NULL THEN
+    SELECT auth.users.email, auth.users.id
+    INTO user_email, user_uuid
+    FROM auth.users
+    WHERE auth.users.email = username_input
+      AND auth.users.email_confirmed_at IS NOT NULL;
+
+    -- Se encontrou na auth mas não na profiles, criar profile
+    IF user_email IS NOT NULL THEN
+      INSERT INTO public.profiles (user_id, username, full_name, role, is_active)
+      VALUES (user_uuid, username_input, username_input, 'operacional', true)
+      ON CONFLICT (user_id) DO UPDATE SET
+        username = EXCLUDED.username,
+        full_name = COALESCE(profiles.full_name, EXCLUDED.full_name),
+        updated_at = now();
+    END IF;
+  END IF;
+
+  IF user_email IS NULL THEN
+    RAISE EXCEPTION 'Username not found or user inactive';
+  END IF;
+
+  RETURN QUERY SELECT user_uuid, user_email;
+END;
+$$;


### PR DESCRIPTION
## Summary
- ensure all security-definer functions set `search_path` to `public`
- add migration recreating functions with explicit `search_path`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, React hooks warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f81c3149c8333b959f41f2b90f758