### PR TITLE
Restrict documentos_colaborador management to administrators

### DIFF
--- a/supabase/migrations/20250815120000_fix_rls_policies.sql
+++ b/supabase/migrations/20250815120000_fix_rls_policies.sql
@@ -35,7 +35,8 @@ CREATE POLICY "Document owner or HR can view documents" ON public.documentos_col
 
 CREATE POLICY "HR can manage documents" ON public.documentos_colaborador
   FOR ALL TO authenticated
-  USING (public.has_role(auth.uid(), 'administrador'));
+  USING (public.has_role(auth.uid(), 'administrador'))
+  WITH CHECK (public.has_role(auth.uid(), 'administrador'));
 
 -- Historico_colaborador: restrict visibility
 DROP POLICY IF EXISTS "Users can view history" ON public.historico_colaborador;

--- a/supabase/migrations/20250821120000_enforce_admin_documentos_policy.sql
+++ b/supabase/migrations/20250821120000_enforce_admin_documentos_policy.sql
@@ -1,0 +1,6 @@
+-- Ensure only administrators can insert or update documentos_colaborador
+DROP POLICY IF EXISTS "HR can manage documents" ON public.documentos_colaborador;
+CREATE POLICY "HR can manage documents" ON public.documentos_colaborador
+  FOR ALL TO authenticated
+  USING (public.has_role(auth.uid(), 'administrador'))
+  WITH CHECK (public.has_role(auth.uid(), 'administrador'));


### PR DESCRIPTION
## Summary
- enforce admin-only access in existing "HR can manage documents" policy by adding WITH CHECK condition
- add migration ensuring only administrators can insert or update documentos_colaborador

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 217 problems (201 errors, 16 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689f8859a7a4833396e3c050a89816f7