### PR TITLE
fix: tighten empresa access check

### DIFF
--- a/supabase/migrations/20250820120000_set_search_path_public.sql
+++ b/supabase/migrations/20250820120000_set_search_path_public.sql
@@ -94,7 +94,7 @@ AS $$
         SELECT 1
         FROM public.colaboradores
         WHERE empresa_id = empresa_uuid
-        AND (created_by = auth.uid() OR updated_at IS NOT NULL)
+        AND created_by = auth.uid()
       )
     );
 $$;

--- a/supabase/migrations/20250822120000_fix_user_can_access_empresa_data.sql
+++ b/supabase/migrations/20250822120000_fix_user_can_access_empresa_data.sql
@@ -1,0 +1,31 @@
+-- Ensure user has real vínculo with company when checking access
+CREATE OR REPLACE FUNCTION public.user_can_access_empresa_data(empresa_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    -- Superusers e administradores têm acesso total
+    has_role(auth.uid(), 'superuser'::user_role) OR
+    has_role(auth.uid(), 'administrador'::user_role) OR
+    -- Usuários empresariais só acessam suas empresas
+    (
+      has_role(auth.uid(), 'empresarial'::user_role) AND
+      empresa_uuid = ANY (
+        SELECT unnest(empresa_ids)
+        FROM public.profiles
+        WHERE user_id = auth.uid()
+      )
+    ) OR
+    -- Usuários operacionais acessam empresas onde trabalham
+    (
+      has_role(auth.uid(), 'operacional'::user_role) AND
+      EXISTS (
+        SELECT 1
+        FROM public.colaboradores
+        WHERE empresa_id = empresa_uuid
+        AND created_by = auth.uid()
+      )
+    );
+$$;


### PR DESCRIPTION
## Summary
- remove placeholder access check relying on `updated_at`
- ensure empresa access validation only passes when collaborator was created by the current user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f884679fc8333affd6daa9bf8932d