### PR TITLE
Restrict historico_colaborador policies

### DIFF
--- a/supabase/migrations/20250820140000_update_historico_colaborador_policies.sql
+++ b/supabase/migrations/20250820140000_update_historico_colaborador_policies.sql
@@ -1,0 +1,25 @@
+-- Update historico_colaborador policies: restrict viewing and inserting
+DROP POLICY IF EXISTS "Admins, business or managers can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Only HR can insert history" ON public.historico_colaborador;
+
+CREATE POLICY "Admins or company members can view history" ON public.historico_colaborador
+  FOR SELECT TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'administrador')
+    OR EXISTS (
+      SELECT 1 FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+        AND public.user_can_access_empresa(c.empresa_id)
+    )
+  );
+
+CREATE POLICY "Only HR of same company can insert history" ON public.historico_colaborador
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.has_role(auth.uid(), 'rh')
+    AND EXISTS (
+      SELECT 1 FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+        AND public.user_can_access_empresa(c.empresa_id)
+    )
+  );


### PR DESCRIPTION
## Summary
- refine historico_colaborador RLS policies to restrict history access to admins or authorized company members and limit inserts to same-company HR

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `supabase db reset` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f989fd88c8333b0ce4f4668729630