### PR TITLE
feat: strengthen auth security

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
     <link rel="canonical" href="/" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://*.supabase.co; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
   </head>
 
   <body>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -48,12 +48,16 @@ interface AuthProviderProps {
   children: ReactNode;
 }
 
+const SESSION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
+
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
+  const sessionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [failedAttempts, setFailedAttempts] = useState(0);
 
   const fetchProfile = async (userId: string) => {
     try {
@@ -81,6 +85,34 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     } catch (error) {
       console.error('Error updating last login:', error);
     }
+  };
+
+  const logLoginAttempt = async (
+    action: 'login_success' | 'login_failure',
+    meta?: Record<string, any>
+  ) => {
+    try {
+      await supabase.from('activity_logs').insert({
+        action,
+        by_user: meta?.username || user?.email || 'unknown',
+        meta: meta ? JSON.stringify(meta) : null
+      });
+    } catch (error) {
+      console.error('Error logging login attempt:', error);
+    }
+  };
+
+  const resetSessionTimeout = () => {
+    if (sessionTimeoutRef.current) {
+      clearTimeout(sessionTimeoutRef.current);
+    }
+    sessionTimeoutRef.current = setTimeout(async () => {
+      await supabase.auth.signOut();
+      toast({
+        title: 'Sessão expirada',
+        description: 'Faça login novamente.'
+      });
+    }, SESSION_TIMEOUT);
   };
 
   const refreshProfile = async () => {
@@ -134,11 +166,24 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return () => subscription.unsubscribe();
   }, []);
 
+  useEffect(() => {
+    if (session) {
+      const events = ['mousemove', 'keydown', 'click'];
+      events.forEach((e) => window.addEventListener(e, resetSessionTimeout));
+      resetSessionTimeout();
+      return () => {
+        events.forEach((e) => window.removeEventListener(e, resetSessionTimeout));
+        if (sessionTimeoutRef.current) {
+          clearTimeout(sessionTimeoutRef.current);
+        }
+      };
+    }
+  }, [session]);
+
   const signIn = async (username: string, password: string) => {
     try {
       setLoading(true);
-      
-      // Get email from username
+
       const { data: authData, error: authError } = await supabase.rpc('authenticate_by_username', {
         username_input: username,
         password_input: password
@@ -151,12 +196,23 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
           description: errorMessage.includes('not found') ? 'Usuário não encontrado ou inativo' : 'Usuário ou senha incorretos',
           variant: 'destructive'
         });
+        await logLoginAttempt('login_failure', { username, reason: errorMessage });
+        setFailedAttempts((prev) => {
+          const count = prev + 1;
+          if (count >= 5) {
+            toast({
+              title: 'Alerta de segurança',
+              description: 'Múltiplas tentativas de login falharam',
+              variant: 'destructive'
+            });
+          }
+          return count;
+        });
         return { error: authError || new Error('Usuário não encontrado') };
       }
 
       const userEmail = authData[0].email;
-      
-      // Now authenticate with Supabase using the email
+
       const { error } = await supabase.auth.signInWithPassword({
         email: userEmail,
         password,
@@ -165,11 +221,26 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       if (error) {
         toast({
           title: 'Erro no login',
-          description: error.message === 'Invalid login credentials' 
-            ? 'Usuário ou senha incorretos' 
+          description: error.message === 'Invalid login credentials'
+            ? 'Usuário ou senha incorretos'
             : error.message,
           variant: 'destructive'
         });
+        await logLoginAttempt('login_failure', { username, reason: error.message });
+        setFailedAttempts((prev) => {
+          const count = prev + 1;
+          if (count >= 5) {
+            toast({
+              title: 'Alerta de segurança',
+              description: 'Múltiplas tentativas de login falharam',
+              variant: 'destructive'
+            });
+          }
+          return count;
+        });
+      } else {
+        await logLoginAttempt('login_success', { username });
+        setFailedAttempts(0);
       }
 
       return { error };
@@ -178,6 +249,18 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         title: 'Erro no login',
         description: 'Ocorreu um erro inesperado. Tente novamente.',
         variant: 'destructive'
+      });
+      await logLoginAttempt('login_failure', { username, reason: 'unexpected_error' });
+      setFailedAttempts((prev) => {
+        const count = prev + 1;
+        if (count >= 5) {
+          toast({
+            title: 'Alerta de segurança',
+            description: 'Múltiplas tentativas de login falharam',
+            variant: 'destructive'
+          });
+        }
+        return count;
       });
       return { error };
     } finally {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,7 @@
 project_id = "pxpscjyeqmqqxzbttbep"
 
 [auth.otp]
-expiry_duration = "60s"  # valor conforme política interna
+expiry_duration = "600s"  # OTP expires after 10 minutes
+
+[auth.password]
+hibp_enabled = true  # enable breached-password protection

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    headers: {
+      'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+      'Content-Security-Policy': "default-src 'self'; connect-src 'self' https://*.supabase.co; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- extend OTP expiry to 10 minutes and enable breached password checks
- add security headers and session timeout logic
- log failed login attempts for anomaly detection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a083315be48333890b891ab3c839c7