### PR TITLE
Add HR activity logging and security monitoring

### DIFF
--- a/.github/workflows/activity-monitor.yml
+++ b/.github/workflows/activity-monitor.yml
@@ -1,0 +1,20 @@
+name: Activity Monitor
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: node scripts/monitor-activity.js
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,17 @@
+name: Dependency Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm audit --production

--- a/README.md
+++ b/README.md
@@ -80,3 +80,18 @@ The `denuncias` table in Supabase uses row-level security:
 - Only authenticated users with the `administrador` role can read, update or delete existing denúncias.
 
 These policies ensure public reporting while keeping report data restricted to administrators.
+
+## Security Incident Response
+
+The application records activity for sensitive HR tables in `public.activity_logs`.
+An automated monitor scans these logs hourly and flags anomalous access patterns.
+
+If a potential security incident is detected:
+
+1. **Contain** – revoke suspicious credentials and isolate affected services.
+2. **Eradicate** – patch vulnerabilities and remove malicious artifacts.
+3. **Recover** – restore from clean backups and verify system integrity.
+4. **Review** – document the incident and update policies and monitoring rules.
+
+Scheduled GitHub Actions also perform weekly dependency audits to surface
+vulnerabilities early.

--- a/scripts/monitor-activity.js
+++ b/scripts/monitor-activity.js
@@ -1,0 +1,47 @@
+import { createClient } from '@supabase/supabase-js';
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+    process.exit(1);
+  }
+
+  const supabase = createClient(url, key);
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { data, error } = await supabase
+    .from('activity_logs')
+    .select('action, by_user, created_at')
+    .gte('created_at', since);
+
+  if (error) {
+    console.error('Error fetching activity logs:', error.message);
+    process.exit(1);
+  }
+
+  const counts = {};
+  for (const row of data) {
+    const key = `${row.by_user}:${row.action}`;
+    counts[key] = (counts[key] || 0) + 1;
+  }
+
+  const alerts = Object.entries(counts).filter(([, count]) => count > 100);
+
+  if (alerts.length > 0) {
+    console.log('Unusual activity detected:');
+    for (const [k, c] of alerts) {
+      console.log(`  ${k} -> ${c} events in last 24h`);
+    }
+    process.exit(1);
+  } else {
+    console.log('No unusual activity detected');
+  }
+}
+
+main().catch((err) => {
+  console.error('Monitoring failed:', err);
+  process.exit(1);
+});

--- a/supabase/migrations/20250825120000_log_hr_activity.sql
+++ b/supabase/migrations/20250825120000_log_hr_activity.sql
@@ -1,0 +1,159 @@
+-- Log HR table access and mutations
+
+-- Function to log SELECT on documentos_colaborador
+CREATE OR REPLACE FUNCTION public.log_documentos_colaborador_access(doc_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.activity_logs(action, by_user, meta)
+  VALUES('select_documento', auth.uid(), jsonb_build_object('documento_id', doc_id));
+  RETURN true;
+END;
+$$;
+
+-- Function to log SELECT on colaboradores
+CREATE OR REPLACE FUNCTION public.log_colaboradores_access(colab_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.activity_logs(action, by_user, meta)
+  VALUES('select_colaborador', auth.uid(), jsonb_build_object('colaborador_id', colab_id));
+  RETURN true;
+END;
+$$;
+
+-- Function to log SELECT on historico_colaborador
+CREATE OR REPLACE FUNCTION public.log_historico_colaborador_access(hist_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.activity_logs(action, by_user, meta)
+  VALUES('select_historico', auth.uid(), jsonb_build_object('historico_id', hist_id));
+  RETURN true;
+END;
+$$;
+
+-- Trigger function for colaboradores table mutations
+CREATE OR REPLACE FUNCTION public.log_colaboradores_activity()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  action_text text;
+  colab_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    action_text := 'insert_colaborador';
+    colab_id := NEW.id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    action_text := 'update_colaborador';
+    colab_id := NEW.id;
+  ELSIF TG_OP = 'DELETE' THEN
+    action_text := 'delete_colaborador';
+    colab_id := OLD.id;
+  END IF;
+
+  INSERT INTO public.activity_logs(action, by_user, meta)
+  VALUES(action_text, auth.uid(), jsonb_build_object('colaborador_id', colab_id));
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER log_colaboradores_activity
+AFTER INSERT OR UPDATE OR DELETE ON public.colaboradores
+FOR EACH ROW EXECUTE FUNCTION public.log_colaboradores_activity();
+
+-- Trigger function for historico_colaborador table mutations
+CREATE OR REPLACE FUNCTION public.log_historico_colaborador_activity()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  action_text text;
+  hist_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    action_text := 'insert_historico';
+    hist_id := NEW.id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    action_text := 'update_historico';
+    hist_id := NEW.id;
+  ELSIF TG_OP = 'DELETE' THEN
+    action_text := 'delete_historico';
+    hist_id := OLD.id;
+  END IF;
+
+  INSERT INTO public.activity_logs(action, by_user, meta)
+  VALUES(action_text, auth.uid(), jsonb_build_object('historico_id', hist_id));
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER log_historico_colaborador_activity
+AFTER INSERT OR UPDATE OR DELETE ON public.historico_colaborador
+FOR EACH ROW EXECUTE FUNCTION public.log_historico_colaborador_activity();
+
+-- Update SELECT policies to include access logging
+DROP POLICY IF EXISTS documentos_select_policy ON public.documentos_colaborador;
+CREATE POLICY documentos_select_policy ON public.documentos_colaborador
+  FOR SELECT TO authenticated
+  USING (
+    public.log_documentos_colaborador_access(documentos_colaborador.id) AND (
+      public.has_role(auth.uid(), 'superuser') OR
+      public.has_role(auth.uid(), 'administrador') OR
+      (
+        public.has_role(auth.uid(), 'empresarial') AND
+        EXISTS (
+          SELECT 1 FROM public.colaboradores c
+          WHERE c.id = documentos_colaborador.colaborador_id
+            AND public.user_can_access_empresa(c.empresa_id)
+        )
+      ) OR (
+        public.has_role(auth.uid(), 'operacional') AND
+        EXISTS (
+          SELECT 1 FROM public.colaboradores c
+          WHERE c.id = documentos_colaborador.colaborador_id
+            AND c.created_by = auth.uid()
+        )
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins or self can view colaborador" ON public.colaboradores;
+CREATE POLICY "Admins or self can view colaborador" ON public.colaboradores
+  FOR SELECT
+  USING (
+    public.log_colaboradores_access(id) AND (
+      public.has_role(auth.uid(), 'administrador')
+      OR auth.uid() = id
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins or company members can view history" ON public.historico_colaborador;
+CREATE POLICY "Admins or company members can view history" ON public.historico_colaborador
+  FOR SELECT TO authenticated
+  USING (
+    public.log_historico_colaborador_access(id) AND (
+      public.has_role(auth.uid(), 'administrador')
+      OR EXISTS (
+        SELECT 1 FROM public.colaboradores c
+        WHERE c.id = historico_colaborador.colaborador_id
+          AND public.user_can_access_empresa(c.empresa_id)
+      )
+    )
+  );


### PR DESCRIPTION
## Summary
- log access and mutations on colaboradores, historico_colaborador, and documentos via activity_logs
- add scheduled scripts to monitor activity logs and run dependency audits
- document security incident response procedures

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm test` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a083342e9083339fa0742971c61e05