### PR TITLE
Add PDF export for filtered colaboradores

### DIFF
--- a/src/components/hr/ColaboradoresPorEmpresa.tsx
+++ b/src/components/hr/ColaboradoresPorEmpresa.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Search, ChevronLeft, ChevronRight, User, Mail, Phone } from "lucide-react";
 import { useSupabaseData } from "@/hooks/useSupabaseData";
+import { ExportPdf } from "./ExportPdf";
 
 interface ColaboradoresPorEmpresaProps {
   empresaId: string;
@@ -87,6 +88,19 @@ export function ColaboradoresPorEmpresa({ empresaId, empresaNome }: Colaboradore
             {filteredColaboradores.length} colaboradores encontrados
           </p>
         </div>
+        <ExportPdf
+          type="empresa"
+          data={{
+            id: empresaId,
+            nome: empresaNome,
+            cnpj: "",
+            endereco: "",
+            responsavel: "",
+            email: "",
+            telefone: "",
+          }}
+          colaboradores={filteredColaboradores}
+        />
       </div>
 
       {/* Campo de Busca com Autocomplete */}


### PR DESCRIPTION
## Summary
- allow HR to export filtered employee lists as PDF
- integrate `ExportPdf` button in `ColaboradoresPorEmpresa`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0866154f88333885c255726fe9a57