### PR TITLE
feat: centralize audit events and calendar editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/context/AuthContext";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import { HRProvider } from "@/context/HRContext";
+import { AuditEventsProvider } from "@/hooks/useAuditEvents";
 import AppLayout from "@/layouts/AppLayout";
 import Index from "./pages/Index";
 import EmpresaDetalhes from "./pages/EmpresaDetalhes";
@@ -31,60 +32,62 @@ const App = () => (
   <QueryClientProvider client={queryClient}>
     <AuthProvider>
       <HRProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
+        <AuditEventsProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Routes>
               {/* Public routes */}
-              <Route path="/" element={<Homepage />} />
-              <Route path="/auth" element={<Auth />} />
-              <Route path="/login" element={<Login />} />
-              <Route path="/denuncia-publica/:empresaId" element={<DenunciaPublica />} />
-              
-              {/* Protected routes */}
-              <Route element={
-                <ProtectedRoute>
-                  <AppLayout />
-                </ProtectedRoute>
-              }>
-                <Route path="/dashboard" element={<Index />} />
-                <Route path="/empresas" element={<Empresas />} />
-                <Route path="/empresa/:empresaId" element={<EmpresaDetalhes />} />
-                <Route path="/debto" element={<DebtosDashboard />} />
-                <Route path="/devedor/:devedorId" element={<DevedorDetalhes />} />
-                <Route path="/denuncias/dashboard" element={<DenunciasDashboard />} />
-                <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
-                
-                {/* Admin only routes */}
-                <Route path="/admin/activity-log" element={
-                  <ProtectedRoute requiredRole="administrador">
-                    <ActivityLog />
-                  </ProtectedRoute>
-                } />
-                <Route path="/admin/system-data" element={
-                  <ProtectedRoute allowedRoles={['superuser', 'administrador']}>
-                    <SystemData />
-                  </ProtectedRoute>
-                } />
-                <Route path="/admin/structure" element={
-                  <ProtectedRoute requiredRole="superuser">
-                    <Structure />
-                  </ProtectedRoute>
-                } />
-                <Route path="/admin/users" element={
-                  <ProtectedRoute allowedRoles={['superuser', 'administrador']}>
-                    <UsersPage />
-                  </ProtectedRoute>
-                } />
-                <Route path="/admin/docs" element={<Docs />} />
-              </Route>
+                <Route path="/" element={<Homepage />} />
+                <Route path="/auth" element={<Auth />} />
+                <Route path="/login" element={<Login />} />
+                <Route path="/denuncia-publica/:empresaId" element={<DenunciaPublica />} />
 
-              {/* 404 */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
-        </TooltipProvider>
+                {/* Protected routes */}
+                <Route element={
+                  <ProtectedRoute>
+                    <AppLayout />
+                  </ProtectedRoute>
+                }>
+                  <Route path="/dashboard" element={<Index />} />
+                  <Route path="/empresas" element={<Empresas />} />
+                  <Route path="/empresa/:empresaId" element={<EmpresaDetalhes />} />
+                  <Route path="/debto" element={<DebtosDashboard />} />
+                  <Route path="/devedor/:devedorId" element={<DevedorDetalhes />} />
+                  <Route path="/denuncias/dashboard" element={<DenunciasDashboard />} />
+                  <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
+
+                  {/* Admin only routes */}
+                  <Route path="/admin/activity-log" element={
+                    <ProtectedRoute requiredRole="administrador">
+                      <ActivityLog />
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/admin/system-data" element={
+                    <ProtectedRoute allowedRoles={['superuser', 'administrador']}>
+                      <SystemData />
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/admin/structure" element={
+                    <ProtectedRoute requiredRole="superuser">
+                      <Structure />
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/admin/users" element={
+                    <ProtectedRoute allowedRoles={['superuser', 'administrador']}>
+                      <UsersPage />
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/admin/docs" element={<Docs />} />
+                </Route>
+
+                {/* 404 */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </TooltipProvider>
+        </AuditEventsProvider>
       </HRProvider>
     </AuthProvider>
   </QueryClientProvider>

--- a/src/hooks/useAuditEvents.tsx
+++ b/src/hooks/useAuditEvents.tsx
@@ -1,0 +1,126 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import { toast } from "sonner";
+
+export interface AuditEvent {
+  id: string;
+  title: string;
+  type: "document" | "training" | "visit" | "meeting";
+  date: Date;
+  status: "scheduled" | "completed" | "overdue";
+  responsible: string;
+}
+
+interface AuditEventsContextValue {
+  events: AuditEvent[];
+  addEvent: (event: Omit<AuditEvent, "id">) => void;
+  updateEvent: (id: string, event: Omit<AuditEvent, "id">) => void;
+  removeEvent: (id: string) => void;
+  syncWithGoogleCalendar: () => Promise<void>;
+}
+
+const AuditEventsContext = createContext<AuditEventsContextValue | undefined>(
+  undefined
+);
+
+const defaultEvents: AuditEvent[] = [
+  {
+    id: "1",
+    title: "Vencimento ISO 9001",
+    type: "document",
+    date: new Date(2024, 1, 20),
+    status: "scheduled",
+    responsible: "João Silva",
+  },
+  {
+    id: "2",
+    title: "Treinamento LGPD",
+    type: "training",
+    date: new Date(2024, 1, 25),
+    status: "scheduled",
+    responsible: "Maria Santos",
+  },
+];
+
+export function AuditEventsProvider({ children }: { children: ReactNode }) {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("audit-events");
+    if (stored) {
+      try {
+        const parsed: AuditEvent[] = JSON.parse(stored).map((e: any) => ({
+          ...e,
+          date: new Date(e.date),
+        }));
+        setEvents(parsed);
+        return;
+      } catch (error) {
+        console.error("Failed to parse stored audit events", error);
+      }
+    }
+    setEvents(defaultEvents);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(
+      "audit-events",
+      JSON.stringify(events.map((e) => ({ ...e, date: e.date.toISOString() })))
+    );
+  }, [events]);
+
+  const addEvent = (event: Omit<AuditEvent, "id">) => {
+    const newEvent: AuditEvent = { ...event, id: crypto.randomUUID() };
+    setEvents((prev) => [...prev, newEvent]);
+  };
+
+  const updateEvent = (id: string, event: Omit<AuditEvent, "id">) => {
+    setEvents((prev) => prev.map((e) => (e.id === id ? { ...event, id } : e)));
+  };
+
+  const removeEvent = (id: string) => {
+    setEvents((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const syncWithGoogleCalendar = async () => {
+    try {
+      // Exemplo de integração utilizando Google API Client
+      const gapi = (window as any).gapi;
+      if (!gapi) throw new Error("Google API client não carregado");
+
+      await gapi.client.load("calendar", "v3");
+
+      for (const event of events) {
+        await gapi.client.calendar.events.insert({
+          calendarId: "primary",
+          resource: {
+            summary: event.title,
+            description: `Responsável: ${event.responsible}`,
+            start: { date: event.date.toISOString().split("T")[0] },
+            end: { date: event.date.toISOString().split("T")[0] },
+          },
+        });
+      }
+      toast.success("Eventos sincronizados com Google Calendar");
+    } catch (error) {
+      console.error(error);
+      toast.error("Falha ao sincronizar com Google Calendar");
+    }
+  };
+
+  return (
+    <AuditEventsContext.Provider
+      value={{ events, addEvent, updateEvent, removeEvent, syncWithGoogleCalendar }}
+    >
+      {children}
+    </AuditEventsContext.Provider>
+  );
+}
+
+export function useAuditEvents() {
+  const ctx = useContext(AuditEventsContext);
+  if (!ctx) {
+    throw new Error("useAuditEvents must be used within AuditEventsProvider");
+  }
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
- add `useAuditEvents` context and provider with Google Calendar sync stub
- wrap app with `AuditEventsProvider`
- refactor audit dashboard to use shared events, highlight calendar days and allow editing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a08684fcec8333820fe74c6f877311