### PR TITLE
feat: send email notifications for public complaints

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,20 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface EmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export async function enviarEmail(options: EmailOptions): Promise<{ success: boolean; error?: unknown }> {
+  try {
+    const { error } = await supabase.functions.invoke("send-email", {
+      body: options,
+    });
+    if (error) throw error;
+    return { success: true };
+  } catch (err) {
+    console.error("Falha ao enviar email:", err);
+    return { success: false, error: err };
+  }
+}

--- a/src/pages/DenunciaPublica.tsx
+++ b/src/pages/DenunciaPublica.tsx
@@ -12,6 +12,7 @@ import { Shield, AlertTriangle, CheckCircle, Eye, EyeOff } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { useHR } from '@/context/HRContext';
+import { enviarEmail } from '@/lib/email';
 
 export default function DenunciaPublica() {
   const { empresaId } = useParams();
@@ -35,7 +36,7 @@ export default function DenunciaPublica() {
   const [submitted, setSubmitted] = useState(false);
   const [protocolo, setProtocolo] = useState('');
   
-  const [empresa, setEmpresa] = useState<{ id: string; nome: string } | null>(null);
+  const [empresa, setEmpresa] = useState<{ id: string; nome: string; email: string } | null>(null);
   const [loadingEmpresa, setLoadingEmpresa] = useState(true);
 
   useEffect(() => {
@@ -44,7 +45,7 @@ export default function DenunciaPublica() {
       try {
         const { data, error } = await supabase
           .from('empresas')
-          .select('id, nome')
+          .select('id, nome, email')
           .eq('id', empresaId)
           .limit(1);
         if (error) throw error;
@@ -121,12 +122,37 @@ export default function DenunciaPublica() {
 
       if (!denuncia) throw new Error('Falha ao criar denúncia');
 
+      const emailDepartamento =
+        empresa?.email && formData.setor
+          ? `${formData.setor.toLowerCase().replace(/\s+/g, '')}@${empresa.email.split('@')[1]}`
+          : null;
+
+      const recipients = [empresa?.email, emailDepartamento].filter(Boolean) as string[];
+
+      const emailResults = await Promise.all(
+        recipients.map((to) =>
+          enviarEmail({
+            to,
+            subject: `Nova denúncia - Protocolo ${denuncia.protocolo}`,
+            html: `<p>Uma nova denúncia foi registrada.</p><p>Protocolo: ${denuncia.protocolo}</p>`
+          })
+        )
+      );
+
+      const failed = emailResults.filter((r) => !r.success);
+      if (failed.length) {
+        console.error('Falha ao enviar notificações por email:', failed.map(f => f.error));
+      }
+
       setProtocolo(denuncia.protocolo);
       setSubmitted(true);
 
       toast({
         title: 'Denúncia registrada',
-        description: `Protocolo ${denuncia.protocolo} gerado com sucesso.`
+        description: failed.length
+          ? `Protocolo ${denuncia.protocolo} gerado, mas houve falha no envio de notificações por email.`
+          : `Protocolo ${denuncia.protocolo} gerado com sucesso.`,
+        variant: failed.length ? 'destructive' : undefined
       });
     } catch (error) {
       console.error('Erro ao registrar denúncia:', error);


### PR DESCRIPTION
## Summary
- add `enviarEmail` utility wrapping Supabase function
- send email notifications to company and department after creating a denúncia
- surface failures when email delivery fails

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68a0867ab3c08333a4f5019702e6ac6d