### PR TITLE
feat: adicionar calendário geral

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import Empresas from "@/pages/Empresas";
 import DebtosDashboard from "@/pages/DebtosDashboard";
 import DevedorDetalhes from "./pages/DevedorDetalhes";
 import Homepage from "@/pages/Homepage";
+import CalendarioGeral from "@/pages/CalendarioGeral";
 
 const queryClient = new QueryClient();
 
@@ -55,6 +56,7 @@ const App = () => (
                 <Route path="/devedor/:devedorId" element={<DevedorDetalhes />} />
                 <Route path="/denuncias/dashboard" element={<DenunciasDashboard />} />
                 <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
+                <Route path="/calendario" element={<CalendarioGeral />} />
                 
                 {/* Admin only routes */}
                 <Route path="/admin/activity-log" element={

--- a/src/components/audit/AuditDashboard.tsx
+++ b/src/components/audit/AuditDashboard.tsx
@@ -12,7 +12,7 @@ import { Activity, FileText, CheckCircle2, AlertTriangle, Clock, Calendar as Cal
 import { useState } from "react";
 import { toast } from "sonner";
 
-interface AuditEvent {
+export interface AuditEvent {
   id: string;
   title: string;
   type: "document" | "training" | "visit" | "meeting";
@@ -20,6 +20,25 @@ interface AuditEvent {
   status: "scheduled" | "completed" | "overdue";
   responsible: string;
 }
+
+export const auditEvents: AuditEvent[] = [
+  {
+    id: "1",
+    title: "Vencimento ISO 9001",
+    type: "document",
+    date: new Date(2024, 1, 20),
+    status: "scheduled",
+    responsible: "João Silva",
+  },
+  {
+    id: "2",
+    title: "Treinamento LGPD",
+    type: "training",
+    date: new Date(2024, 1, 25),
+    status: "scheduled",
+    responsible: "Maria Santos",
+  },
+];
 
 export function AuditDashboard() {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
@@ -79,25 +98,6 @@ export function AuditDashboard() {
       type: "Visita",
       result: "Aprovado",
       responseTime: "45min"
-    }
-  ];
-
-  const auditEvents: AuditEvent[] = [
-    {
-      id: "1",
-      title: "Vencimento ISO 9001",
-      type: "document",
-      date: new Date(2024, 1, 20),
-      status: "scheduled",
-      responsible: "João Silva"
-    },
-    {
-      id: "2",
-      title: "Treinamento LGPD",
-      type: "training", 
-      date: new Date(2024, 1, 25),
-      status: "scheduled",
-      responsible: "Maria Santos"
     }
   ];
 

--- a/src/pages/CalendarioGeral.tsx
+++ b/src/pages/CalendarioGeral.tsx
@@ -1,0 +1,130 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Calendar } from "@/components/ui/calendar";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { auditEvents } from "@/components/audit/AuditDashboard";
+import { useHR } from "@/context/HRContext";
+import { useDebtoData } from "@/hooks/useDebtoData";
+
+interface CalendarEvent {
+  id: string;
+  title: string;
+  date: Date;
+  module: "audit" | "divida" | "denuncia";
+  link: string;
+}
+
+export default function CalendarioGeral() {
+  const navigate = useNavigate();
+  const { denuncias } = useHR();
+  const { dividas } = useDebtoData();
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+  const [moduleFilter, setModuleFilter] = useState<string>("all");
+
+  const events: CalendarEvent[] = useMemo(() => {
+    const audit = auditEvents.map((e) => ({
+      id: `audit-${e.id}`,
+      title: e.title,
+      date: e.date,
+      module: "audit" as const,
+      link: "/dashboard",
+    }));
+
+    const debts = dividas.map((d) => ({
+      id: `divida-${d.id}`,
+      title: `Dívida ${d.origem_divida}`,
+      date: new Date(d.data_vencimento),
+      module: "divida" as const,
+      link: `/devedor/${d.devedor_id}`,
+    }));
+
+    const reports = denuncias.map((d) => ({
+      id: `denuncia-${d.id}`,
+      title: `Denúncia ${d.protocolo}`,
+      date: new Date(d.createdAt),
+      module: "denuncia" as const,
+      link: `/denuncias/dashboard`,
+    }));
+
+    return [...audit, ...debts, ...reports];
+  }, [dividas, denuncias]);
+
+  const modifiers = useMemo(
+    () => ({ highlight: events.map((e) => e.date) }),
+    [events]
+  );
+
+  const filteredEvents = events.filter((e) => {
+    const sameDay = selectedDate
+      ? e.date.toDateString() === selectedDate.toDateString()
+      : true;
+    const moduleMatch = moduleFilter === "all" || e.module === moduleFilter;
+    return sameDay && moduleMatch;
+  });
+
+  const moduleLabels: Record<CalendarEvent["module"], string> = {
+    audit: "Auditoria",
+    divida: "Dívida",
+    denuncia: "Denúncia",
+  };
+
+  const moduleBadgeStyles: Record<CalendarEvent["module"], string> = {
+    audit: "bg-blue-100 text-blue-800",
+    divida: "bg-red-100 text-red-800",
+    denuncia: "bg-yellow-100 text-yellow-800",
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <CardTitle>Calendário Geral</CardTitle>
+          <Select value={moduleFilter} onValueChange={setModuleFilter}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Todos os módulos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos</SelectItem>
+              <SelectItem value="audit">Auditoria</SelectItem>
+              <SelectItem value="divida">Dívidas</SelectItem>
+              <SelectItem value="denuncia">Denúncias</SelectItem>
+            </SelectContent>
+          </Select>
+        </CardHeader>
+        <CardContent className="flex flex-col md:flex-row gap-6">
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={setSelectedDate}
+            modifiers={modifiers}
+            modifiersClassNames={{ highlight: "bg-primary text-primary-foreground" }}
+            className="rounded-md border"
+          />
+          <div className="flex-1 space-y-2">
+            {filteredEvents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Nenhum evento para esta data.
+              </p>
+            ) : (
+              filteredEvents.map((event) => (
+                <div
+                  key={event.id}
+                  onClick={() => navigate(event.link)}
+                  className="p-3 border rounded-lg cursor-pointer hover:bg-muted/50 flex items-center justify-between"
+                >
+                  <span>{event.title}</span>
+                  <Badge className={moduleBadgeStyles[event.module]}>
+                    {moduleLabels[event.module]}
+                  </Badge>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- adicionar página de calendário geral com eventos de auditoria, dívidas e denúncias
- exportar eventos de auditoria para uso externo
- incluir rota protegida para o novo calendário

## Testing
- `npm install --no-audit --no-fund` (falhou: 403 Forbidden - GET https://registry.npmjs.org/vitest)
- `npm test` (falhou: vitest: not found)
- `npm run lint` (falhou: Cannot find package 'globals')


------
https://chatgpt.com/codex/tasks/task_e_68a0867941748333a9184605e5a7bae2