### PR TITLE
refactor: unify spacing in auditoria components

### DIFF
--- a/src/components/hr/AuditoriaEmpresa.tsx
+++ b/src/components/hr/AuditoriaEmpresa.tsx
@@ -272,7 +272,7 @@ export function AuditoriaEmpresa({ empresaId, nomeEmpresa }: AuditoriaEmpresaPro
   const categoriasDisponiveis = Object.keys(categorias);
 
   return (
-    <div className="space-y-6">
+    <div className="container mx-auto p-4 space-y-6">
       {/* Header com estatísticas */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card>
@@ -313,8 +313,8 @@ export function AuditoriaEmpresa({ empresaId, nomeEmpresa }: AuditoriaEmpresaPro
       </div>
 
       {/* Tabs por categoria */}
-      <Tabs defaultValue={Object.keys(categorias)[0]} className="w-full">
-        <div className="flex items-center justify-between mb-4">
+      <Tabs defaultValue={Object.keys(categorias)[0]} className="w-full space-y-4">
+        <div className="flex items-center justify-between gap-4">
           <TabsList className="grid grid-cols-5 w-full max-w-4xl">
             {Object.keys(categorias).map((categoria) => (
               <TabsTrigger key={categoria} value={categoria} className="text-xs">

--- a/src/pages/EmpresaDetalhes.tsx
+++ b/src/pages/EmpresaDetalhes.tsx
@@ -721,7 +721,7 @@ export default function EmpresaDetalhes() {
 
         </TabsContent>
 
-          <TabsContent value="auditoria" className="space-y-8">
+          <TabsContent value="auditoria" className="space-y-6">
             <Tabs defaultValue="dashboard" className="w-full">
               <TabsList className="grid w-full grid-cols-2">
                 <TabsTrigger value="dashboard">Dashboard</TabsTrigger>


### PR DESCRIPTION
## Summary
- wrap auditoria view in `container mx-auto p-4` and adjust tab spacing
- align EmpresaDetalhes auditoria tab with consistent `space-y-6`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 226 problems, e.g. no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b1868214833390eb55fd9449256f