### PR TITLE
feat: hide dashboard link for anonymous users

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -2,8 +2,10 @@ import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import logoGold from "@/assets/logo-gold.png";
 import logoDark from "@/assets/logo-dark.png";
+import { useAuth } from "@/context/AuthContext";
 
 export function Header() {
+  const { user } = useAuth();
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/40">
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
@@ -24,16 +26,30 @@ export function Header() {
         </div>
         
         <nav className="hidden md:flex items-center space-x-8">
-          <Link to="/dashboard" className="text-muted-foreground hover:text-foreground transition-colors">
-            Dashboard
-          </Link>
-          <Link to="/sobre" className="text-muted-foreground hover:text-foreground transition-colors">
+          {user && (
+            <Link
+              to="/dashboard"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Dashboard
+            </Link>
+          )}
+          <Link
+            to="/sobre"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
             Sobre
           </Link>
-          <Link to="/servicos" className="text-muted-foreground hover:text-foreground transition-colors">
+          <Link
+            to="/servicos"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
             Serviços
           </Link>
-          <Link to="/contato" className="text-muted-foreground hover:text-foreground transition-colors">
+          <Link
+            to="/contato"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
             Contato
           </Link>
         </nav>


### PR DESCRIPTION
## Summary
- show Dashboard link only when user is authenticated
- keep login button as sole entry point for visitors

## Testing
- `npm run lint` *(fails: Unexpected any, React hook dependency warnings across project)*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68a0b1965af083338806345f30f352b4