### PR TITLE
Swap login and dashboard links

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -26,12 +26,12 @@ export function Header() {
         </div>
         
         <nav className="hidden md:flex items-center space-x-8">
-          {user && (
+          {!user && (
             <Link
-              to="/dashboard"
+              to="/auth"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >
-              Dashboard
+              Login
             </Link>
           )}
           <Link
@@ -55,8 +55,8 @@ export function Header() {
         </nav>
 
         <Button asChild variant="default">
-          <Link to="/auth">
-            Login
+          <Link to="/dashboard">
+            Dashboard
           </Link>
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Show Login link only when user is logged out
- Use dashboard button instead of login button in header

## Testing
- `npm run lint` *(fails: 236 problems (213 errors, 23 warnings))*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0bb0b38ac8333ac14a7de285c4b30