### PR TITLE
Expose complaint lookup link on public header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,8 @@ const App = () => (
               <Route path="/auth" element={<Auth />} />
               <Route path="/login" element={<Login />} />
               <Route path="/denuncia-publica/:empresaId" element={<DenunciaPublica />} />
-              
+              <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
+
               {/* Protected routes */}
               <Route element={
                 <ProtectedRoute>
@@ -54,7 +55,6 @@ const App = () => (
                 <Route path="/debto" element={<DebtosDashboard />} />
                 <Route path="/devedor/:devedorId" element={<DevedorDetalhes />} />
                 <Route path="/denuncias/dashboard" element={<DenunciasDashboard />} />
-                <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
                 
                 {/* Admin only routes */}
                 <Route path="/admin/activity-log" element={

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -27,7 +27,6 @@ export function AppSidebar() {
     { title: "Empresas", url: "/empresas", icon: Building2, show: true },
     { title: "Debto - Cobranças", url: "/debto", icon: DollarSign, show: true },
     { title: "Dashboard Denúncias", url: "/denuncias/dashboard", icon: Shield, show: true },
-    { title: "Consultar Denúncia", url: "/denuncias/consulta", icon: Activity, show: true },
     { title: "Log de Atividades", url: "/admin/activity-log", icon: Activity, show: true },
     { title: "Dados do Sistema", url: "/admin/system-data", icon: Settings2, show: true },
     { title: "Estrutura", url: "/admin/structure", icon: ListTree, show: true },

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -2,10 +2,8 @@ import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import logoGold from "@/assets/logo-gold.png";
 import logoDark from "@/assets/logo-dark.png";
-import { useAuth } from "@/context/AuthContext";
 
 export function Header() {
-  const { user } = useAuth();
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/40">
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
@@ -26,14 +24,12 @@ export function Header() {
         </div>
         
         <nav className="hidden md:flex items-center space-x-8">
-          {!user && (
-            <Link
-              to="/auth"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Login
-            </Link>
-          )}
+          <Link
+            to="/denuncias/consulta"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Consultar Denúncia
+          </Link>
           <Link
             to="/sobre"
             className="text-muted-foreground hover:text-foreground transition-colors"

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -14,13 +14,11 @@ const AppLayout: React.FC = () => {
     const titles: Record<string, string> = {
       "/": "MRx Compliance - Painel",
       "/denuncias/dashboard": "Denúncias - Dashboard",
-      "/denuncias/consulta": "Consultar Denúncia",
       "/auth": "Entrar - MRx Compliance",
     };
     const descriptions: Record<string, string> = {
       "/": "Painel de compliance e RH com visão geral e métricas.",
       "/denuncias/dashboard": "Acompanhe denúncias: abertas, em andamento e concluídas.",
-      "/denuncias/consulta": "Consultar denúncia por protocolo de forma segura.",
       "/auth": "Acesse sua conta no MRx Compliance com segurança.",
     };
 


### PR DESCRIPTION
## Summary
- replace homepage login link with public "Consultar Denúncia" link
- remove internal menu and SEO references for complaint lookup
- move complaint lookup route outside protected area

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a0be6941908333b15d4e66860d3a4e