### PR TITLE
feat: expose denuncia consulta publicly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ const App = () => (
               <Route path="/auth" element={<Auth />} />
               <Route path="/login" element={<Login />} />
               <Route path="/denuncia-publica/:empresaId" element={<DenunciaPublica />} />
+              <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
               
               {/* Protected routes */}
               <Route element={
@@ -54,7 +55,6 @@ const App = () => (
                 <Route path="/debto" element={<DebtosDashboard />} />
                 <Route path="/devedor/:devedorId" element={<DevedorDetalhes />} />
                 <Route path="/denuncias/dashboard" element={<DenunciasDashboard />} />
-                <Route path="/denuncias/consulta" element={<ConsultaDenuncia />} />
                 
                 {/* Admin only routes */}
                 <Route path="/admin/activity-log" element={

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,5 +1,17 @@
 import { NavLink, useLocation } from "react-router-dom";
-import { Activity, BookText, Building2, Home, ListTree, Settings2, Shield, Users, LogOut, DollarSign } from "lucide-react";
+import {
+  Activity,
+  BookText,
+  Building2,
+  Home,
+  ListTree,
+  Settings2,
+  Shield,
+  Users,
+  LogOut,
+  DollarSign,
+  type LucideIcon,
+} from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import {
   Sidebar,
@@ -20,14 +32,13 @@ export function AppSidebar() {
   const location = useLocation();
   const path = location.pathname;
 
-  type Item = { title: string; url: string; icon: React.ComponentType<any>; show: boolean };
+  type Item = { title: string; url: string; icon: LucideIcon; show: boolean };
 
   const items: Item[] = [
     { title: "Painel", url: "/", icon: Home, show: true },
     { title: "Empresas", url: "/empresas", icon: Building2, show: true },
     { title: "Debto - Cobranças", url: "/debto", icon: DollarSign, show: true },
     { title: "Dashboard Denúncias", url: "/denuncias/dashboard", icon: Shield, show: true },
-    { title: "Consultar Denúncia", url: "/denuncias/consulta", icon: Activity, show: true },
     { title: "Log de Atividades", url: "/admin/activity-log", icon: Activity, show: true },
     { title: "Dados do Sistema", url: "/admin/system-data", icon: Settings2, show: true },
     { title: "Estrutura", url: "/admin/structure", icon: ListTree, show: true },

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -48,8 +48,8 @@ export function Header() {
         </nav>
 
         <Button asChild variant="default">
-          <Link to="/dashboard">
-            Login
+          <Link to="/denuncias/consulta">
+            Consultar Denúncia
           </Link>
         </Button>
       </div>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -3,7 +3,6 @@ import { Outlet, useLocation } from "react-router-dom";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { Logo } from "@/components/ui/logo";
-import { Button } from "@/components/ui/button";
 
 const AppLayout: React.FC = () => {
   const location = useLocation();
@@ -14,13 +13,11 @@ const AppLayout: React.FC = () => {
     const titles: Record<string, string> = {
       "/": "MRx Compliance - Painel",
       "/denuncias/dashboard": "Denúncias - Dashboard",
-      "/denuncias/consulta": "Consultar Denúncia",
       "/auth": "Entrar - MRx Compliance",
     };
     const descriptions: Record<string, string> = {
       "/": "Painel de compliance e RH com visão geral e métricas.",
       "/denuncias/dashboard": "Acompanhe denúncias: abertas, em andamento e concluídas.",
-      "/denuncias/consulta": "Consultar denúncia por protocolo de forma segura.",
       "/auth": "Acesse sua conta no MRx Compliance com segurança.",
     };
 


### PR DESCRIPTION
## Summary
- replace dashboard button with public denúncia consultation link in header
- move denúncia consultation route out of protected routes
- remove consultation entry from sidebar and layout metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*
- `npx eslint src/components/ui/header.tsx src/App.tsx src/components/app-sidebar.tsx src/layouts/AppLayout.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1fe9414833394cae4cacb89cbc7