### PR TITLE
Restrict colaboradores policies

### DIFF
--- a/supabase/migrations/20250826120000_update_colaboradores_policies.sql
+++ b/supabase/migrations/20250826120000_update_colaboradores_policies.sql
@@ -1,0 +1,28 @@
+-- Tighten colaboradores policies to restrict access
+
+-- Drop overly permissive policy
+DROP POLICY IF EXISTS "All authenticated users can view colaboradores" ON public.colaboradores;
+
+-- Allow collaborators to view their own record or administrators to view any
+CREATE POLICY "Self or admin can view colaborador" ON public.colaboradores
+  FOR SELECT
+  USING (
+    auth.uid() = id
+    OR has_role(auth.uid(), 'administrador'::user_role)
+  );
+
+-- Only HR administrators may insert collaborators
+CREATE POLICY "HR admins can insert colaboradores" ON public.colaboradores
+  FOR INSERT
+  WITH CHECK (has_role(auth.uid(), 'administrador'::user_role));
+
+-- Only HR administrators may update collaborators
+CREATE POLICY "HR admins can update colaboradores" ON public.colaboradores
+  FOR UPDATE
+  USING (has_role(auth.uid(), 'administrador'::user_role))
+  WITH CHECK (has_role(auth.uid(), 'administrador'::user_role));
+
+-- Only HR administrators may delete collaborators
+CREATE POLICY "HR admins can delete colaboradores" ON public.colaboradores
+  FOR DELETE
+  USING (has_role(auth.uid(), 'administrador'::user_role));


### PR DESCRIPTION
## Summary
- drop overly permissive colaboradores policy
- enforce self-or-admin select policy
- limit colaboradores modifications to administrators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dac966e88333af86d245ef31a1a0