### PR TITLE
Restrict processos_judiciais policies to advocacia and admins

### DIFF
--- a/supabase/migrations/20250826120000_restrict_processos_advocacia_policies.sql
+++ b/supabase/migrations/20250826120000_restrict_processos_advocacia_policies.sql
@@ -1,0 +1,56 @@
+-- Drop existing SELECT policy that allowed any empresa access
+DROP POLICY IF EXISTS "Users can view processos based on empresa access" ON public.processos_judiciais;
+
+-- Drop existing admin policy to replace with stricter role-based policies
+DROP POLICY IF EXISTS "Admins can manage processos" ON public.processos_judiciais;
+
+-- Allow only advocacia or administrators to view processos for their empresa
+CREATE POLICY "Advocacia or admins can view processos" 
+ON public.processos_judiciais FOR SELECT
+USING (
+  user_can_access_empresa(empresa_id)
+  AND (
+    has_role(auth.uid(), 'advocacia'::user_role)
+    OR has_role(auth.uid(), 'administrador'::user_role)
+  )
+);
+
+-- Allow only advocacia or administrators to insert processos for their empresa
+CREATE POLICY "Advocacia or admins can insert processos" 
+ON public.processos_judiciais FOR INSERT
+WITH CHECK (
+  user_can_access_empresa(empresa_id)
+  AND (
+    has_role(auth.uid(), 'advocacia'::user_role)
+    OR has_role(auth.uid(), 'administrador'::user_role)
+  )
+);
+
+-- Allow only advocacia or administrators to update processos for their empresa
+CREATE POLICY "Advocacia or admins can update processos" 
+ON public.processos_judiciais FOR UPDATE
+USING (
+  user_can_access_empresa(empresa_id)
+  AND (
+    has_role(auth.uid(), 'advocacia'::user_role)
+    OR has_role(auth.uid(), 'administrador'::user_role)
+  )
+)
+WITH CHECK (
+  user_can_access_empresa(empresa_id)
+  AND (
+    has_role(auth.uid(), 'advocacia'::user_role)
+    OR has_role(auth.uid(), 'administrador'::user_role)
+  )
+);
+
+-- Allow only advocacia or administrators to delete processos for their empresa
+CREATE POLICY "Advocacia or admins can delete processos" 
+ON public.processos_judiciais FOR DELETE
+USING (
+  user_can_access_empresa(empresa_id)
+  AND (
+    has_role(auth.uid(), 'advocacia'::user_role)
+    OR has_role(auth.uid(), 'administrador'::user_role)
+  )
+);


### PR DESCRIPTION
## Summary
- remove legacy processos_judiciais policies
- restrict processos_judiciais access to `advocacia` and `administrador` roles with matching empresa

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 214 errors, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dad81cd483338fc287b71812832e