### PR TITLE
Restrict dividas access to cobranca and finance roles

### DIFF
--- a/supabase/migrations/20250826120000_update_dividas_policies.sql
+++ b/supabase/migrations/20250826120000_update_dividas_policies.sql
@@ -1,0 +1,60 @@
+-- Update dividas policies to require cobranca or financeiro roles
+DROP POLICY IF EXISTS "Users can view dividas based on role" ON public.dividas;
+DROP POLICY IF EXISTS "View dividas with role" ON public.dividas;
+DROP POLICY IF EXISTS "Manage dividas with finance roles" ON public.dividas;
+
+CREATE POLICY "View dividas for cobranca or financeiro"
+  ON public.dividas
+  FOR SELECT
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'cobranca'::user_role)
+      OR has_role(auth.uid(), 'financeiro'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+    )
+  );
+
+CREATE POLICY "Insert dividas for cobranca or financeiro"
+  ON public.dividas
+  FOR INSERT
+  WITH CHECK (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'cobranca'::user_role)
+      OR has_role(auth.uid(), 'financeiro'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+    )
+  );
+
+CREATE POLICY "Update dividas for cobranca or financeiro"
+  ON public.dividas
+  FOR UPDATE
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'cobranca'::user_role)
+      OR has_role(auth.uid(), 'financeiro'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+    )
+  )
+  WITH CHECK (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'cobranca'::user_role)
+      OR has_role(auth.uid(), 'financeiro'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+    )
+  );
+
+CREATE POLICY "Delete dividas for cobranca or financeiro"
+  ON public.dividas
+  FOR DELETE
+  USING (
+    user_can_access_empresa(empresa_id)
+    AND (
+      has_role(auth.uid(), 'cobranca'::user_role)
+      OR has_role(auth.uid(), 'financeiro'::user_role)
+      OR has_role(auth.uid(), 'administrador'::user_role)
+    )
+  );


### PR DESCRIPTION
## Summary
- overhaul dividas row-level policies to require cobranca, financeiro, or administrator roles
- ensure SELECT/INSERT/UPDATE/DELETE all check empresa_id ownership and allowed roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 214 errors, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dad5db808333afee9f1d90b2e818