### PR TITLE
feat: enable HIBP password validation

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,8 @@
 project_id = "pxpscjyeqmqqxzbttbep"
 
+[auth.password]
+hibp_enabled = true
+hibp_api_key = { env = "HIBP_API_KEY" }
+
 [auth.otp]
 expiry_duration = "60s"  # valor conforme política interna


### PR DESCRIPTION
## Summary
- enable Have-I-Been-Pwned password checks via `hibp_enabled`
- add `hibp_api_key` env reference for API key configuration

## Testing
- `npm run lint` *(fails: Unexpected any, React Hook useEffect has a missing dependency)*
- `npx supabase db reset` *(fails: 403 Forbidden fetching supabase CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dadfb15c8333a65e85060c7c98f8