### PR TITLE
Document OTP expiry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ The `denuncias` table in Supabase uses row-level security:
 
 These policies ensure public reporting while keeping report data restricted to administrators.
 
+## Authentication OTP Expiry
+
+Supabase one-time passwords (OTPs) expire **60 seconds** after issuance as configured in
+`supabase/config.toml`. This complies with the organization policy requiring tokens to
+expire in 60 seconds or less.
+
 ## Security Incident Response
 
 The application records activity for sensitive HR tables in `public.activity_logs`.


### PR DESCRIPTION
## Summary
- confirm Supabase OTP expiry is 60s
- document current OTP expiry policy in README

## Testing
- ⚠️ `npm test` *(fails: Missing script: "test")*
- ⚠️ `npm run lint` *(214 errors, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dade18e48333979cd867a21d6ca5