### PR TITLE
Restrict denuncias access to compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 The `denuncias` table in Supabase uses row-level security:
 
 - Anonymous users may submit new denúncias but cannot view, update or delete any entries.
-- Only authenticated users with the `administrador` role can read, update or delete existing denúncias.
+- Only authenticated users with the `compliance` role or superusers can read, update or delete existing denúncias.
 
-These policies ensure public reporting while keeping report data restricted to administrators.
+These policies ensure public reporting while keeping report data restricted to the compliance team.
 
 ## Authentication OTP Expiry
 
@@ -101,3 +101,7 @@ If a potential security incident is detected:
 
 Scheduled GitHub Actions also perform weekly dependency audits to surface
 vulnerabilities early.
+
+## Compliance
+
+See [docs/compliance_credentials_rotation.md](docs/compliance_credentials_rotation.md) for the credential rotation procedure for the compliance team.

--- a/docs/compliance_credentials_rotation.md
+++ b/docs/compliance_credentials_rotation.md
@@ -1,0 +1,24 @@
+# Compliance Credential Rotation
+
+To maintain secure access to sensitive denuncia data, rotate credentials for the compliance team regularly.
+
+## Rotation Steps
+
+1. **Schedule**: Plan rotation during a low-usage window and notify the compliance team in advance.
+2. **Create new credentials**:
+   - Generate new passwords or API keys for each compliance member.
+   - Record credentials in the secure secrets manager.
+3. **Update services**:
+   - Replace old credentials in environment variables and server configurations.
+   - Redeploy services or restart sessions that depend on these credentials.
+4. **Distribute securely**:
+   - Share new credentials with compliance officers via the approved secure channel.
+   - Require confirmation of receipt.
+5. **Revoke old credentials**:
+   - Remove or disable previous passwords and keys.
+   - Audit logs to ensure no further usage of retired credentials.
+6. **Document**:
+   - Record the rotation event and participants for auditing.
+   - Update next scheduled rotation date.
+
+Regular credential rotation limits the window of exposure if credentials are compromised and ensures continuous compliance with security policies.

--- a/supabase/migrations/20250828120000_restrict_denuncias_to_compliance.sql
+++ b/supabase/migrations/20250828120000_restrict_denuncias_to_compliance.sql
@@ -1,0 +1,66 @@
+-- Restrict denuncias table access to compliance officers and superusers
+-- Provide anonymized view for broader consumption
+-- Extend audit logging for select access
+
+-- Drop existing policies
+DROP POLICY IF EXISTS "Compliance officers and admins can view denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admins can update company denuncias" ON public.denuncias;
+DROP POLICY IF EXISTS "Admins can delete company denuncias" ON public.denuncias;
+
+-- Log read access with user and timestamp
+CREATE OR REPLACE FUNCTION public.log_denuncia_access(denuncia_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.activity_logs(action, by_user, meta)
+  VALUES(
+    'select_denuncia',
+    auth.uid(),
+    jsonb_build_object('denuncia_id', denuncia_id, 'timestamp', now())
+  );
+  RETURN true;
+END;
+$$;
+
+-- Policies restricted to compliance and superusers
+CREATE POLICY "Compliance and superuser can view denuncias" ON public.denuncias
+  FOR SELECT TO authenticated
+  USING (
+    public.get_user_role() IN ('compliance','superuser')
+    AND public.log_denuncia_access(id)
+  );
+
+CREATE POLICY "Compliance and superuser can update denuncias" ON public.denuncias
+  FOR UPDATE TO authenticated
+  USING (public.get_user_role() IN ('compliance','superuser'))
+  WITH CHECK (public.get_user_role() IN ('compliance','superuser'));
+
+CREATE POLICY "Compliance and superuser can delete denuncias" ON public.denuncias
+  FOR DELETE TO authenticated
+  USING (public.get_user_role() IN ('compliance','superuser'));
+
+-- View masking reporter identifiers
+CREATE OR REPLACE VIEW public.denuncias_public AS
+SELECT
+  id,
+  protocolo,
+  empresa_id,
+  identificado,
+  relacao,
+  tipo,
+  setor,
+  conhecimento_fato,
+  envolvidos_cientes,
+  descricao,
+  evidencias_descricao,
+  sugestao,
+  anexos,
+  status,
+  created_at,
+  updated_at
+FROM public.denuncias;
+
+GRANT SELECT ON public.denuncias_public TO anon, authenticated;


### PR DESCRIPTION
## Summary
- limit `public.denuncias` RLS policies so only compliance officers and superusers may read, update, or delete
- add `denuncias_public` view with reporter data removed and log read access via `log_denuncia_access`
- document compliance credential rotation procedure and reference it in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0ded804a08333949f129ee407ed92