### PR TITLE
refactor: update collaborator history fields

### DIFF
--- a/src/components/hr/AdicionarObservacao.tsx
+++ b/src/components/hr/AdicionarObservacao.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -59,13 +60,14 @@ export function AdicionarObservacao({ colaboradorId, onObservacaoAdicionada }: A
         tipo: 'image'
       }));
 
+      const user = (await supabase.auth.getUser()).data.user;
       const novaObservacao = {
         id: Date.now().toString(),
+        colaborador_id: colaboradorId,
         observacao: observacao,
-        data: new Date().toISOString(),
-        usuario: 'Usuário Atual', // Pegar do contexto de auth
-        anexos: anexosUrls,
-        created_at: new Date().toISOString()
+        created_at: new Date().toISOString(),
+        created_by: user?.id || 'usuario_atual',
+        anexos: anexosUrls
       };
 
       // Aqui você salvaria no banco de dados

--- a/src/components/hr/AdicionarObservacaoInline.tsx
+++ b/src/components/hr/AdicionarObservacaoInline.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
@@ -27,12 +28,13 @@ export function AdicionarObservacaoInline({ colaboradorId, onObservacaoAdicionad
     setIsLoading(true);
 
     try {
+      const user = (await supabase.auth.getUser()).data.user;
       const novaObservacao = {
         id: Date.now().toString(),
+        colaborador_id: colaboradorId,
         observacao: observacao,
-        data: new Date().toISOString(),
-        usuario: 'Usuário Atual', // Pegar do contexto de auth
-        created_at: new Date().toISOString()
+        created_at: new Date().toISOString(),
+        created_by: user?.id || 'usuario_atual'
       };
 
       // Aqui você salvaria no banco de dados

--- a/src/types/hr.ts
+++ b/src/types/hr.ts
@@ -8,15 +8,10 @@ export interface DocumentoColaborador {
 
 export interface HistoricoColaborador {
   id: string;
-  data: string;
+  colaborador_id: string;
   observacao: string;
-  usuario: string;
-  created_at?: string;
-  anexos?: Array<{
-    nome: string;
-    url: string;
-    tipo: string;
-  }>;
+  created_at: string;
+  created_by: string;
 }
 
 export interface Colaborador {


### PR DESCRIPTION
## Summary
- redefine collaborator history to include author and timestamp info
- adjust observation components and views to use created_at/created_by
- load author names from profiles when fetching collaborator history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 216 errors, 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e0e124fc8333ba780c87b8135810