### PR TITLE
feat: fetch collaborator historico and update observacoes

### DIFF
--- a/src/components/hr/AdicionarObservacao.tsx
+++ b/src/components/hr/AdicionarObservacao.tsx
@@ -6,11 +6,13 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { MessageCircle, Upload, X, Image } from 'lucide-react';
+import { MessageCircle, X, Image } from 'lucide-react';
+import { saveObservacao } from '@/lib/historico';
+import { HistoricoColaborador } from '@/types/hr';
 
 interface AdicionarObservacaoProps {
   colaboradorId: string;
-  onObservacaoAdicionada: (observacao: any) => void;
+  onObservacaoAdicionada: (observacao: HistoricoColaborador) => void;
 }
 
 export function AdicionarObservacao({ colaboradorId, onObservacaoAdicionada }: AdicionarObservacaoProps) {
@@ -53,23 +55,17 @@ export function AdicionarObservacao({ colaboradorId, onObservacaoAdicionada }: A
 
     try {
       // Simular upload de arquivos (você pode implementar upload real aqui)
-      const anexosUrls = anexos.map((file, index) => ({
+      const anexosUrls = anexos.map((file) => ({
         nome: file.name,
         url: URL.createObjectURL(file), // Em produção, usar URL real do upload
         tipo: 'image'
       }));
 
-      const novaObservacao = {
-        id: Date.now().toString(),
-        observacao: observacao,
-        data: new Date().toISOString(),
-        usuario: 'Usuário Atual', // Pegar do contexto de auth
-        anexos: anexosUrls,
-        created_at: new Date().toISOString()
-      };
-
-      // Aqui você salvaria no banco de dados
-      // await saveObservacao(colaboradorId, novaObservacao);
+      const novaObservacao = await saveObservacao(
+        colaboradorId,
+        observacao,
+        anexosUrls
+      );
 
       onObservacaoAdicionada(novaObservacao);
       

--- a/src/components/hr/AdicionarObservacaoInline.tsx
+++ b/src/components/hr/AdicionarObservacaoInline.tsx
@@ -3,10 +3,12 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { Plus } from 'lucide-react';
+import { saveObservacao } from '@/lib/historico';
+import { HistoricoColaborador } from '@/types/hr';
 
 interface AdicionarObservacaoInlineProps {
   colaboradorId: string;
-  onObservacaoAdicionada: (observacao: any) => void;
+  onObservacaoAdicionada: (observacao: HistoricoColaborador) => void;
 }
 
 export function AdicionarObservacaoInline({ colaboradorId, onObservacaoAdicionada }: AdicionarObservacaoInlineProps) {
@@ -27,16 +29,10 @@ export function AdicionarObservacaoInline({ colaboradorId, onObservacaoAdicionad
     setIsLoading(true);
 
     try {
-      const novaObservacao = {
-        id: Date.now().toString(),
-        observacao: observacao,
-        data: new Date().toISOString(),
-        usuario: 'Usuário Atual', // Pegar do contexto de auth
-        created_at: new Date().toISOString()
-      };
-
-      // Aqui você salvaria no banco de dados
-      // await saveObservacao(colaboradorId, novaObservacao);
+      const novaObservacao = await saveObservacao(
+        colaboradorId,
+        observacao
+      );
 
       onObservacaoAdicionada(novaObservacao);
       

--- a/src/components/hr/VisualizacaoColaborador.tsx
+++ b/src/components/hr/VisualizacaoColaborador.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -25,11 +25,10 @@ import {
   TrendingUp,
   Image
 } from 'lucide-react';
-import { Colaborador } from '@/types/hr';
+import { Colaborador, HistoricoColaborador } from '@/types/hr';
 import { ExportPdf } from './ExportPdf';
-import { AdicionarObservacao } from './AdicionarObservacao';
 import { AdicionarObservacaoInline } from './AdicionarObservacaoInline';
-import { Logo } from '@/components/ui/logo';
+import { fetchHistorico } from '@/lib/historico';
 import { calcularRescisaoColaborador, calcularValorPrevisto } from '@/lib/rescisao';
 
 interface VisualizacaoColaboradorProps {
@@ -146,7 +145,19 @@ function RescisaoContent({ colaborador }: { colaborador: Colaborador }) {
 
 export function VisualizacaoColaborador({ colaborador, onClose, onEdit }: VisualizacaoColaboradorProps) {
   const [activeTab, setActiveTab] = useState('pessoais');
-  const [historico, setHistorico] = useState(colaborador.historico || []);
+  const [historico, setHistorico] = useState<HistoricoColaborador[]>([]);
+
+  useEffect(() => {
+    const carregarHistorico = async () => {
+      try {
+        const data = await fetchHistorico(colaborador.id);
+        setHistorico(data);
+      } catch (error) {
+        console.error('Erro ao carregar histórico:', error);
+      }
+    };
+    carregarHistorico();
+  }, [colaborador.id]);
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -169,7 +180,7 @@ export function VisualizacaoColaborador({ colaborador, onClose, onEdit }: Visual
     return new Date(data).toLocaleDateString('pt-BR');
   };
 
-  const handleObservacaoAdicionada = (novaObservacao: any) => {
+  const handleObservacaoAdicionada = (novaObservacao: HistoricoColaborador) => {
     setHistorico(prev => [novaObservacao, ...prev]);
   };
 
@@ -615,7 +626,7 @@ export function VisualizacaoColaborador({ colaborador, onClose, onEdit }: Visual
                           {entrada.anexos && entrada.anexos.length > 0 && (
                             <div className="mt-3 mb-3">
                               <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
-                                {entrada.anexos.map((anexo: any, anexoIndex: number) => (
+                                {entrada.anexos.map((anexo: { nome: string; url: string; tipo: string }, anexoIndex: number) => (
                                   <div key={anexoIndex} className="relative">
                                     <img
                                       src={anexo.url}

--- a/src/components/hr/VisualizacaoColaboradorCompleta.tsx
+++ b/src/components/hr/VisualizacaoColaboradorCompleta.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -8,6 +8,7 @@ import { Separator } from '@/components/ui/separator';
 import { DocumentsManager } from './DocumentsManager';
 import { AdicionarObservacaoInline } from './AdicionarObservacaoInline';
 import { EtiquetasColaborador } from './EtiquetasColaborador';
+import { fetchHistorico } from '@/lib/historico';
 import {
   User,
   Mail,
@@ -30,7 +31,7 @@ import {
   Image,
   AlertTriangle
 } from 'lucide-react';
-import { Colaborador } from '@/types/hr';
+import { Colaborador, HistoricoColaborador } from '@/types/hr';
 import { ExportPdf } from './ExportPdf';
 import { calcularRescisaoColaborador, calcularValorPrevisto } from '@/lib/rescisao';
 
@@ -41,7 +42,19 @@ interface VisualizacaoColaboradorCompletaProps {
 }
 
 export function VisualizacaoColaboradorCompleta({ colaborador, onClose, onEdit }: VisualizacaoColaboradorCompletaProps) {
-  const [historico, setHistorico] = useState(colaborador.historico || []);
+  const [historico, setHistorico] = useState<HistoricoColaborador[]>([]);
+
+  useEffect(() => {
+    const carregarHistorico = async () => {
+      try {
+        const data = await fetchHistorico(colaborador.id);
+        setHistorico(data);
+      } catch (error) {
+        console.error('Erro ao carregar histórico:', error);
+      }
+    };
+    carregarHistorico();
+  }, [colaborador.id]);
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'ATIVO':
@@ -67,7 +80,7 @@ export function VisualizacaoColaboradorCompleta({ colaborador, onClose, onEdit }
   const valorRescisao = 'totalEstimado' in rescisao ? parseFloat(rescisao.totalEstimado) : 0;
   const valorPrevisto = calcularValorPrevisto(valorRescisao);
 
-  const handleObservacaoAdicionada = (novaObservacao: any) => {
+  const handleObservacaoAdicionada = (novaObservacao: HistoricoColaborador) => {
     setHistorico(prev => [novaObservacao, ...prev]);
   };
 
@@ -379,15 +392,15 @@ export function VisualizacaoColaboradorCompleta({ colaborador, onClose, onEdit }
                    <div className="grid grid-cols-3 gap-4">
                      <div>
                        <label className="text-sm font-medium text-muted-foreground">Periculosidade</label>
-                       <p className="font-semibold">{formatarMoeda((colaborador as any)?.periculosidade || 0)}</p>
+                       <p className="font-semibold">{formatarMoeda((colaborador as Record<string, number | undefined>)?.periculosidade || 0)}</p>
                      </div>
                      <div>
                        <label className="text-sm font-medium text-muted-foreground">Insalubridade</label>
-                       <p className="font-semibold">{formatarMoeda((colaborador as any)?.insalubridade || 0)}</p>
+                       <p className="font-semibold">{formatarMoeda((colaborador as Record<string, number | undefined>)?.insalubridade || 0)}</p>
                      </div>
                      <div>
                        <label className="text-sm font-medium text-muted-foreground">Outros Valores</label>
-                       <p className="font-semibold">{formatarMoeda((colaborador as any)?.outros_valores || 0)}</p>
+                       <p className="font-semibold">{formatarMoeda((colaborador as Record<string, number | undefined>)?.outros_valores || 0)}</p>
                      </div>
                    </div>
                  </div>
@@ -649,7 +662,7 @@ export function VisualizacaoColaboradorCompleta({ colaborador, onClose, onEdit }
                             {obs.anexos && obs.anexos.length > 0 && (
                               <div className="mt-2">
                                 <div className="grid grid-cols-3 gap-1">
-                                  {obs.anexos.map((anexo: any, anexoIndex: number) => (
+                                  {obs.anexos.map((anexo: { nome: string; url: string; tipo: string }, anexoIndex: number) => (
                                     <div key={anexoIndex} className="relative">
                                       <img
                                         src={anexo.url}

--- a/src/lib/historico.ts
+++ b/src/lib/historico.ts
@@ -1,0 +1,35 @@
+import { supabase } from '@/integrations/supabase/client';
+import { HistoricoColaborador } from '@/types/hr';
+
+export async function fetchHistorico(colaboradorId: string): Promise<HistoricoColaborador[]> {
+  const { data, error } = await supabase
+    .from('historico_colaborador')
+    .select('*')
+    .eq('colaborador_id', colaboradorId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  return (data || []) as HistoricoColaborador[];
+}
+
+export async function saveObservacao(
+  colaboradorId: string,
+  observacao: string,
+  anexos?: HistoricoColaborador['anexos']
+): Promise<HistoricoColaborador> {
+  const { data: user } = await supabase.auth.getUser();
+  const { data, error } = await supabase
+    .from('historico_colaborador')
+    .insert({
+      colaborador_id: colaboradorId,
+      observacao,
+      created_by: user.user?.id,
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  // Return saved record with anexos if provided (not stored in DB)
+  return { ...(data as HistoricoColaborador), anexos };
+}
+


### PR DESCRIPTION
## Summary
- load collaborator historico from Supabase on view mount
- persist new observations and prepend to historico list
- add historico helpers for fetching and saving

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 238 problems across repo)*
- `npx eslint src/lib/historico.ts src/components/hr/AdicionarObservacao.tsx src/components/hr/AdicionarObservacaoInline.tsx src/components/hr/VisualizacaoColaborador.tsx src/components/hr/VisualizacaoColaboradorCompleta.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0e30fd4833398089b10fba6c28c