### PR TITLE
feat(auth): add compliance role

### DIFF
--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -396,6 +396,7 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                         <SelectItem value="operacional">Operacional</SelectItem>
                         <SelectItem value="empresarial">Empresarial</SelectItem>
                         <SelectItem value="administrador">Administrador</SelectItem>
+                        <SelectItem value="compliance">Compliance</SelectItem>
                         <SelectItem value="superuser">Superuser</SelectItem>
                       </SelectContent>
                     </Select>
@@ -559,6 +560,7 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                         <SelectItem value="operacional">Operacional</SelectItem>
                         <SelectItem value="empresarial">Empresarial</SelectItem>
                         <SelectItem value="administrador">Administrador</SelectItem>
+                        <SelectItem value="compliance">Compliance</SelectItem>
                         <SelectItem value="superuser">Superuser</SelectItem>
                       </SelectContent>
                     </Select>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,7 +3,7 @@ import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
-export type UserRole = 'superuser' | 'administrador' | 'empresarial' | 'operacional';
+export type UserRole = 'superuser' | 'administrador' | 'compliance' | 'empresarial' | 'operacional';
 
 export interface UserProfile {
   id: string;
@@ -262,8 +262,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     if (!profile) return false;
     
     const roleHierarchy = {
-      'superuser': 4,
-      'administrador': 3,
+      'superuser': 5,
+      'administrador': 4,
+      'compliance': 3,
       'empresarial': 2,
       'operacional': 1
     };


### PR DESCRIPTION
## Summary
- add new `compliance` role to `UserRole` type and authorization hierarchy
- expose `compliance` option in user management role selectors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0e3e43883339eb1452cf9a39cb8