### PR TITLE
feat: centralize collaborator history utilities

### DIFF
--- a/src/components/hr/DocumentsManager.tsx
+++ b/src/components/hr/DocumentsManager.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Upload, FileText, X, Download, Trash2 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import { saveObservacao } from '@/lib/historico';
 import { toast } from 'sonner';
 
 interface Document {
@@ -147,14 +148,11 @@ export function DocumentsManager({ colaboradorId, onDocumentChange }: DocumentsM
         throw new Error(`Erro ao salvar documento: ${docError.message}`);
       }
 
-      // Add to history
-      await supabase
-        .from('historico_colaborador')
-        .insert({
-          colaborador_id: colaboradorId,
-          observacao: `Documento adicionado: ${selectedFile.name} (${documentType})`,
-          created_by: (await supabase.auth.getUser()).data.user?.id
-        });
+      // Registra o envio no histórico utilizando utilitário compartilhado
+      await saveObservacao(
+        colaboradorId,
+        `Documento adicionado: ${selectedFile.name} (${documentType})`
+      );
 
       toast.success('Documento enviado com sucesso!');
       
@@ -196,15 +194,12 @@ export function DocumentsManager({ colaboradorId, onDocumentChange }: DocumentsM
 
       if (error) throw error;
 
-      // Add to history  
+      // Registra a remoção no histórico através do utilitário padronizado
       const document = documents.find(d => d.id === docId);
-      await supabase
-        .from('historico_colaborador')
-        .insert({
-          colaborador_id: colaboradorId,
-          observacao: `Documento removido: ${document?.nome || 'Documento'}`,
-          created_by: (await supabase.auth.getUser()).data.user?.id
-        });
+      await saveObservacao(
+        colaboradorId,
+        `Documento removido: ${document?.nome || 'Documento'}`
+      );
 
       toast.success('Documento removido com sucesso!');
       await loadDocuments();

--- a/src/lib/historico.ts
+++ b/src/lib/historico.ts
@@ -1,0 +1,65 @@
+import { supabase } from '@/integrations/supabase/client';
+import { HistoricoColaborador } from '@/types/hr';
+
+/**
+ * Converte um registro bruto do Supabase para o formato utilizado pela aplicação.
+ * Pode ser reutilizado por componentes que precisem padronizar a exibição do histórico.
+ */
+export const formatarHistorico = (item: any): HistoricoColaborador => ({
+  id: item.id,
+  data: item.created_at,
+  observacao: item.observacao,
+  usuario: item.created_by,
+  created_at: item.created_at,
+});
+
+/**
+ * Salva uma nova observação no histórico do colaborador.
+ * Centraliza validação de campos obrigatórios e tratamento de erros.
+ */
+export const saveObservacao = async (colaboradorId: string, observacao: string) => {
+  if (!colaboradorId || !observacao?.trim()) {
+    throw new Error('colaboradorId e observacao são obrigatórios');
+  }
+
+  const { data: userData } = await supabase.auth.getUser();
+  const { data, error } = await supabase
+    .from('historico_colaborador')
+    .insert({
+      colaborador_id: colaboradorId,
+      observacao,
+      created_by: userData.user?.id,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Erro ao salvar observação: ${error.message}`);
+  }
+
+  return formatarHistorico(data);
+};
+
+/**
+ * Busca o histórico completo de um colaborador já formatado.
+ */
+export const fetchHistorico = async (colaboradorId: string): Promise<HistoricoColaborador[]> => {
+  const { data, error } = await supabase
+    .from('historico_colaborador')
+    .select('*')
+    .eq('colaborador_id', colaboradorId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Erro ao buscar histórico: ${error.message}`);
+  }
+
+  return (data || []).map(formatarHistorico);
+};
+
+export default {
+  saveObservacao,
+  fetchHistorico,
+  formatarHistorico,
+};
+


### PR DESCRIPTION
## Summary
- add shared historico helpers to save and fetch collaborator history
- use saveObservacao in HRContext and DocumentsManager instead of manual inserts
- document history utility usage for easier integration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0e4ec688333983ea1ab3d7dc39c