### PR TITLE
Handle error adding employee history comment

### DIFF
--- a/src/lib/historico.ts
+++ b/src/lib/historico.ts
@@ -1,13 +1,14 @@
 import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/context/AuthContext';
 import type { Database } from '@/integrations/supabase/types';
 
 export type HistoricoColaboradorRow = Database['public']['Tables']['historico_colaborador']['Row'];
 
 export async function saveObservacao(colaboradorId: string, observacao: string): Promise<HistoricoColaboradorRow> {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { user } = useAuth();
-
+  const { data: userData, error: authError } = await supabase.auth.getUser();
+  if (authError) {
+    throw new Error(authError.message || 'Falha ao obter usuário autenticado');
+  }
+  const user = userData.user;
   if (!user?.id) {
     throw new Error('Usuário não autenticado');
   }


### PR DESCRIPTION
Fixes React hook error by replacing `useAuth` with `supabase.auth.getUser()` in `src/lib/historico.ts`.

The original error (React #321) occurred because `useAuth` (a React hook) was being called inside `saveObservacao`, which is a utility function and not a React component, violating the rules of hooks. This change resolves that by fetching the user directly from Supabase.

---
<a href="https://cursor.com/background-agent?bcId=bc-83964444-736e-4101-94f2-0baaca87d28b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83964444-736e-4101-94f2-0baaca87d28b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

