### PR TITLE
Fix debt registration error

### DIFF
--- a/src/hooks/useDebtoData.ts
+++ b/src/hooks/useDebtoData.ts
@@ -180,21 +180,39 @@ export function useDebtoData() {
   const adicionarDivida = async (dividaData: Partial<Divida>) => {
     try {
       const { data: user } = await supabase.auth.getUser();
-      
+
+      // Apenas colunas existentes na tabela `dividas`
+      const payload = {
+        devedor_id: dividaData.devedor_id,
+        empresa_id: dividaData.empresa_id,
+        numero_contrato: dividaData.numero_contrato,
+        numero_nf: dividaData.numero_nf,
+        origem_divida: dividaData.origem_divida,
+        data_vencimento: dividaData.data_vencimento,
+        valor_original: dividaData.valor_original,
+        valor_atualizado: dividaData.valor_atualizado,
+        status: dividaData.status,
+        estagio: dividaData.estagio,
+        data_negativacao: dividaData.data_negativacao,
+        data_protesto: dividaData.data_protesto,
+        urgency_score: dividaData.urgency_score,
+        created_by: user.user?.id,
+      } as any;
+
       const { data, error } = await supabase
         .from('dividas')
-        .insert(dividaData as any)
+        .insert(payload)
         .select()
         .single();
 
       if (error) throw error;
-      
+
       setDividas(prev => [data as Divida, ...prev]);
       toast.success('Dívida cadastrada com sucesso!');
       return data;
-    } catch (error) {
+    } catch (error: any) {
       console.error('Erro ao adicionar dívida:', error);
-      toast.error('Erro ao cadastrar dívida');
+      toast.error(`Erro ao cadastrar dívida: ${error?.message ?? 'tente novamente'}`);
       throw error;
     }
   };

--- a/supabase/migrations/20250901120000_allow_cobranca_insert_dividas.sql
+++ b/supabase/migrations/20250901120000_allow_cobranca_insert_dividas.sql
@@ -1,0 +1,17 @@
+-- Allow cobranca role to insert dividas (in addition to administrators)
+-- This replaces the stricter policy that only allowed administrators
+
+-- Drop old insert policy if it exists
+DROP POLICY IF EXISTS "Admins can insert dividas" ON public.dividas;
+
+-- Create new insert policy for cobranca and administrators
+CREATE POLICY "Cobranca and admins can insert dividas" ON public.dividas
+  FOR INSERT
+  WITH CHECK (
+    user_can_access_empresa(empresa_id) AND
+    (
+      has_role(auth.uid(), 'cobranca'::user_role) OR
+      has_role(auth.uid(), 'administrador'::user_role)
+    )
+  );
+


### PR DESCRIPTION
Fixes "erro ao cadastrar dívida" by refining data insertion and relaxing RLS policy for `cobranca` role.

The previous RLS policy on `public.dividas` only allowed administrators to insert new records, which prevented users with the `cobranca` role from performing this action. Additionally, the insert payload was made explicit to ensure only valid columns are sent and `created_by` is included. The error toast now displays the underlying Supabase error for better debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-1786d79e-8f7a-4343-a6d5-71778238b00e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1786d79e-8f7a-4343-a6d5-71778238b00e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

