### PR TITLE
Corrigir salvamento de observacoes do colaborador

### DIFF
--- a/supabase/migrations/20250910120000_fix_historico_colaborador_policies.sql
+++ b/supabase/migrations/20250910120000_fix_historico_colaborador_policies.sql
@@ -1,0 +1,43 @@
+-- Fix historico_colaborador RLS to allow inserts/views for users with access to the collaborator's company
+
+-- Drop conflicting/old policies
+DROP POLICY IF EXISTS "Admins, business or managers can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Only HR can insert history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Admins or company members can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Only HR of same company can insert history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "HR or managers can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "HR or managers can insert history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Managers can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Managers can insert history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Users can view history" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Authenticated users can insert history" ON public.historico_colaborador;
+
+-- View policy: any authenticated user who can access the collaborator's company (via user_can_access_empresa)
+CREATE POLICY "Users with company access can view historico_colaborador"
+  ON public.historico_colaborador
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+        AND public.user_can_access_empresa(c.empresa_id)
+    )
+  );
+
+-- Insert policy: require same company access AND that created_by matches the authenticated user
+CREATE POLICY "Users with company access can insert historico_colaborador"
+  ON public.historico_colaborador
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = created_by
+    AND EXISTS (
+      SELECT 1
+      FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+        AND public.user_can_access_empresa(c.empresa_id)
+    )
+  );
+


### PR DESCRIPTION
Relax RLS policies for `historico_colaborador` to allow authenticated users to save observations.

Previously, RLS policies on `historico_colaborador` restricted inserts to the 'rh' role, causing observations to fail to save for most users. This PR updates the policies to allow any authenticated user with access to the collaborator's company to insert and view observations, ensuring `created_by` matches the current user.

---
<a href="https://cursor.com/background-agent?bcId=bc-24ebfd7c-a540-4833-b850-8b9c725e21ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24ebfd7c-a540-4833-b850-8b9c725e21ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

