### PR TITLE
Fix public report link 404 error

### DIFF
--- a/src/pages/DenunciaPublica.tsx
+++ b/src/pages/DenunciaPublica.tsx
@@ -78,7 +78,9 @@ export default function DenunciaPublica() {
     );
   }
 
-  if (!loadingEmpresa && !empresa) {
+  // Se não conseguirmos carregar a empresa (por exemplo, RLS bloqueando SELECT para usuários anônimos),
+  // ainda assim permitimos o acesso público ao formulário. Só redirecionamos caso não haja empresaId.
+  if (!empresaId) {
     return <Navigate to="/404" replace />;
   }
 
@@ -201,6 +203,11 @@ export default function DenunciaPublica() {
             </div>
             <CardTitle className="text-2xl">Canal de Denúncias</CardTitle>
             <p className="text-muted-foreground">{empresa?.nome ?? 'Empresa'}</p>
+            {!empresa && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Canal público ativo. O nome da empresa pode não aparecer para proteger dados internos.
+              </p>
+            )}
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="bg-blue-50 p-4 rounded-lg">


### PR DESCRIPTION
Allow public access to the DenunciaPublica form by preventing 404 redirects when company details cannot be loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-d43b6d2a-0cb8-4c48-a0ae-29e1164522a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d43b6d2a-0cb8-4c48-a0ae-29e1164522a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

