### PR TITLE
Anexar e exibir arquivos na página de denúncias

### DIFF
--- a/supabase/migrations/20250831120000_create_denuncia_anexos_bucket.sql
+++ b/supabase/migrations/20250831120000_create_denuncia_anexos_bucket.sql
@@ -1,0 +1,47 @@
+-- Create storage bucket for denuncia attachments
+INSERT INTO storage.buckets (id, name, public) VALUES ('denuncia-anexos', 'denuncia-anexos', false);
+
+-- Allow anyone (including anonymous) to upload into denuncia-anexos
+CREATE POLICY "Anyone can upload denuncia anexos"
+ON storage.objects 
+FOR INSERT 
+WITH CHECK (
+  bucket_id = 'denuncia-anexos'
+);
+
+-- Allow admins and superusers to view denuncia anexos
+CREATE POLICY "Admins can view denuncia anexos" 
+ON storage.objects 
+FOR SELECT 
+USING (
+  bucket_id = 'denuncia-anexos' AND
+  (
+    has_role(auth.uid(), 'superuser'::user_role) OR
+    has_role(auth.uid(), 'administrador'::user_role)
+  )
+);
+
+-- Allow admins and superusers to update denuncia anexos
+CREATE POLICY "Admins can update denuncia anexos" 
+ON storage.objects 
+FOR UPDATE 
+USING (
+  bucket_id = 'denuncia-anexos' AND
+  (
+    has_role(auth.uid(), 'superuser'::user_role) OR
+    has_role(auth.uid(), 'administrador'::user_role)
+  )
+);
+
+-- Allow admins and superusers to delete denuncia anexos
+CREATE POLICY "Admins can delete denuncia anexos" 
+ON storage.objects 
+FOR DELETE 
+USING (
+  bucket_id = 'denuncia-anexos' AND
+  (
+    has_role(auth.uid(), 'superuser'::user_role) OR
+    has_role(auth.uid(), 'administrador'::user_role)
+  )
+);
+


### PR DESCRIPTION
Adiciona funcionalidade de anexos (upload e listagem) para denúncias, com limite de 10MB por arquivo.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c7f350e-3e31-4a47-ba0f-969f587f5322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c7f350e-3e31-4a47-ba0f-969f587f5322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

