### PR TITLE
Ajustar kanbam para tema escuro e otimizar layout

### DIFF
--- a/src/components/tarefas/TaskKPICards.tsx
+++ b/src/components/tarefas/TaskKPICards.tsx
@@ -70,21 +70,21 @@ export function TaskKPICards({ kpis }: TaskKPICardsProps) {
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7 gap-4">
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 xl:grid-cols-7 gap-3">
       {cards.map((card) => {
         const Icon = card.icon;
         return (
           <Card key={card.title} className="relative overflow-hidden">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1">
+              <CardTitle className="text-xs font-medium text-muted-foreground">
                 {card.title}
               </CardTitle>
-              <div className={`p-2 rounded-full ${card.bgColor}`}>
-                <Icon className={`h-4 w-4 ${card.color}`} />
+              <div className={`p-1.5 rounded-full ${card.bgColor}`}>
+                <Icon className={`h-3.5 w-3.5 ${card.color}`} />
               </div>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{card.value}</div>
+              <div className="text-xl font-bold">{card.value}</div>
               {(card.title === 'Atrasadas' && card.value > 0) && (
                 <Badge variant="destructive" className="mt-1">
                   Requer atenção

--- a/src/components/ui/kanban-new.tsx
+++ b/src/components/ui/kanban-new.tsx
@@ -22,7 +22,7 @@ interface KanbanProps {
 
 export const Kanban = ({ tasks, onTaskUpdate, onTaskCreate, onTaskDelete, loading = false }: KanbanProps) => {
   return (
-    <div className={cn("h-full w-full bg-background text-foreground")}>
+    <div className={cn("h-full w-full bg-neutral-900 text-neutral-100")}>
       <Board 
         tasks={tasks}
         onTaskUpdate={onTaskUpdate}
@@ -83,7 +83,7 @@ const Board = ({ tasks, onTaskUpdate, onTaskCreate, onTaskDelete, loading }: Boa
           onTaskCreate={onTaskCreate}
         />
       ))}
-      <BurnBarrel onTaskDelete={onTaskDelete} />
+      {/* Lixeira removida para aumentar área útil do quadro */}
     </div>
   );
 };
@@ -211,8 +211,8 @@ const Column = ({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         className={`h-full w-full transition-colors rounded-lg ${
-          active ? "bg-muted/50" : "bg-background"
-        } min-h-[500px] border-2 border-dashed ${active ? "border-primary" : "border-transparent"}`}
+          active ? "bg-neutral-700/60" : "bg-neutral-800"
+        } min-h-[500px] border-2 border-dashed ${active ? "border-primary" : "border-neutral-700"}`}
       >
         {filteredTasks
           .sort((a, b) => a.ordem_na_coluna - b.ordem_na_coluna)
@@ -260,7 +260,7 @@ const TaskCard = ({ task, handleDragStart }: TaskCardProps) => {
         layoutId={task.id}
         draggable="true"
         onDragStart={(e: any) => handleDragStart(e, task)}
-        className="cursor-grab rounded-lg border bg-card text-card-foreground shadow-sm p-4 mb-3 active:cursor-grabbing hover:shadow-md transition-all hover:border-primary/50 group"
+        className="cursor-grab rounded-lg border border-neutral-700 bg-neutral-800 text-neutral-100 shadow-sm p-4 mb-3 active:cursor-grabbing hover:shadow-md transition-all hover:border-primary/50 group"
       >
         <div className="space-y-3">
           {/* Header with title and avatar */}
@@ -404,7 +404,7 @@ const AddCard = ({ column, onTaskCreate }: AddCardProps) => {
     <motion.button
       layout
       onClick={() => onTaskCreate(column)}
-      className="flex w-full items-center gap-1.5 px-3 py-4 text-xs text-muted-foreground transition-colors hover:text-foreground rounded-lg hover:bg-muted/50 border-2 border-dashed border-transparent hover:border-primary/50"
+      className="flex w-full items-center gap-1.5 px-3 py-3 text-xs text-neutral-300 transition-colors hover:text-white rounded-lg hover:bg-neutral-700/50 border-2 border-dashed border-neutral-700 hover:border-primary/50"
     >
       <FiPlus className="h-4 w-4" />
       <span>Adicionar tarefa</span>

--- a/src/pages/TarefasDashboard.tsx
+++ b/src/pages/TarefasDashboard.tsx
@@ -127,7 +127,7 @@ export default function TarefasDashboard() {
         </div>
       </div>
 
-      {/* KPIs */}
+      {/* KPIs (compactos) */}
       <TaskKPICards kpis={kpis} />
 
       {/* Filters */}
@@ -152,7 +152,7 @@ export default function TarefasDashboard() {
         </CardHeader>
         <CardContent className="p-0">
           {view === 'kanban' ? (
-            <div className="h-[calc(100vh-400px)] min-h-[600px]">
+            <div className="h-[calc(100vh-480px)] min-h-[520px]">
               <Kanban
                 tasks={filteredTarefas}
                 onTaskUpdate={handleTaskReorder}


### PR DESCRIPTION
Apply dark theme to Kanban, remove trash icon, and compact KPI cards to fit content on screen.

The user requested a dark/grey theme for the Kanban board and a reorganization of the layout (removing the trash icon and reducing KPI card size) to ensure all content fits within a single screen without scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-905ce2db-d296-446d-a5fb-3de9a5339668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-905ce2db-d296-446d-a5fb-3de9a5339668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

