### PR TITLE
Investigate disappearing os cards

### DIFF
--- a/src/pages/TarefasDashboard.tsx
+++ b/src/pages/TarefasDashboard.tsx
@@ -153,7 +153,6 @@ export default function TarefasDashboard() {
                 onTaskCreate={handleTaskCreateFromColumn}
                 onTaskDelete={deleteTarefa}
                 loading={loading}
-                hideCards
               />
             </div>
           ) : (


### PR DESCRIPTION
Remove `hideCards` prop from Kanban component to display task cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-f31d671d-1bf2-4234-805d-04232f49b22c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f31d671d-1bf2-4234-805d-04232f49b22c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

