### PR TITLE
Criar visualização de cartão ao clicar

### DIFF
--- a/src/pages/Empresas.tsx
+++ b/src/pages/Empresas.tsx
@@ -299,7 +299,7 @@ const Empresas = () => {
           } catch {}
 
           return (
-            <Card key={empresa.id} className="transition-all hover:shadow-lg">
+            <Card key={empresa.id} className="transition-all hover:shadow-lg cursor-pointer" onClick={() => navigate(`/empresa/${empresa.id}`)}>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
                 <div className="flex items-center gap-3">
                   <div className="p-2 bg-primary text-primary-foreground rounded-lg">
@@ -325,7 +325,7 @@ const Empresas = () => {
                   </div>
                 </div>
                 <div className="flex gap-2">
-                  <Button variant="outline" size="sm" onClick={() => navigate(`/empresa/${empresa.id}`)} className="gap-2">
+                  <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); navigate(`/empresa/${empresa.id}`); }} className="gap-2">
                     <Eye className="h-4 w-4" /> Ver detalhes
                   </Button>
                   <AlertDialog>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -126,7 +126,7 @@ const Index = () => {
               const complianceRate = getComplianceRateFromAuditoria(empresa.id);
               
               return (
-                <Card key={empresa.id} className="transition-all hover:shadow-lg cursor-pointer">
+                <Card key={empresa.id} className="transition-all hover:shadow-lg cursor-pointer" onClick={() => navigate(`/empresa/${empresa.id}`)}>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
                     <div className="flex items-center space-x-3">
                       <div className="p-2 bg-primary text-primary-foreground rounded-lg">
@@ -140,7 +140,7 @@ const Index = () => {
                     <Button 
                       variant="outline" 
                       size="sm"
-                      onClick={() => navigate(`/empresa/${empresa.id}`)}
+                      onClick={(e) => { e.stopPropagation(); navigate(`/empresa/${empresa.id}`); }}
                       className="flex items-center gap-2"
                     >
                       <Eye className="h-4 w-4" />


### PR DESCRIPTION
Permite clicar nos cartões de empresa para navegar para a página de detalhes e previne a propagação de cliques nos botões internos.

---
<a href="https://cursor.com/background-agent?bcId=bc-91618c90-d3a6-4c09-8676-e825ed2d7364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91618c90-d3a6-4c09-8676-e825ed2d7364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

