### PR TITLE
Fix collaborator history save error

### DIFF
--- a/supabase/migrations/20250920130000_update_historico_colaborador_policies_access_data.sql
+++ b/supabase/migrations/20250920130000_update_historico_colaborador_policies_access_data.sql
@@ -1,0 +1,35 @@
+-- Update historico_colaborador RLS to use user_can_access_empresa_data
+
+-- Clean up prior policies to avoid duplicates/conflicts
+DROP POLICY IF EXISTS "Users with company access can view historico_colaborador" ON public.historico_colaborador;
+DROP POLICY IF EXISTS "Users with company access can insert historico_colaborador" ON public.historico_colaborador;
+
+-- View policy: any authenticated user who can access the collaborator's company (via user_can_access_empresa_data)
+CREATE POLICY "Users with company access can view historico_colaborador"
+  ON public.historico_colaborador
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+        AND public.user_can_access_empresa_data(c.empresa_id)
+    )
+  );
+
+-- Insert policy: require access to the company AND that created_by matches the authenticated user
+CREATE POLICY "Users with company access can insert historico_colaborador"
+  ON public.historico_colaborador
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = created_by
+    AND EXISTS (
+      SELECT 1
+      FROM public.colaboradores c
+      WHERE c.id = historico_colaborador.colaborador_id
+        AND public.user_can_access_empresa_data(c.empresa_id)
+    )
+  );
+


### PR DESCRIPTION
Update `historico_colaborador` RLS policies to use `user_can_access_empresa_data` to fix history record insertion failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-ceeace7a-d6ba-43be-85f6-1fd0fc8fb6d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ceeace7a-d6ba-43be-85f6-1fd0fc8fb6d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

