### PR TITLE
Investigate new agreement registration error

### DIFF
--- a/src/components/debto/AcordoManager.tsx
+++ b/src/components/debto/AcordoManager.tsx
@@ -123,7 +123,8 @@ export function AcordoManager({ dividaId, devedorId, valorOriginal, onAcordoCria
         dividaId,
         {
           status: 'acordado',
-          data_vencimento: format(acordo.data_entrada, 'yyyy-MM-dd')
+          data_vencimento: format(acordo.data_entrada, 'yyyy-MM-dd'),
+          valor_atualizado: acordo.valor_total
         },
         false
       );
@@ -135,7 +136,7 @@ export function AcordoManager({ dividaId, devedorId, valorOriginal, onAcordoCria
         tipo_acao: 'acordo',
         canal: 'sistema',
         descricao: `Acordo criado: ${formatCurrency(acordo.valor_total)} em ${acordo.numero_parcelas} parcelas. Nova data de vencimento: ${format(acordo.data_entrada, 'dd/MM/yyyy')}`,
-        resultado: 'sucesso',
+        resultado: 'acordo_fechado',
         valor_negociado: acordo.valor_total,
         observacoes: `Forma de pagamento: ${acordo.forma_pagamento}. ${acordo.observacoes || ''}`
       });


### PR DESCRIPTION
Updates debt's `valor_atualizado` and uses a valid `resultado` for `historico_cobrancas` to fix 400 error on agreement creation.

The `historico_cobrancas` table has a `CHECK` constraint on the `resultado` column, which did not permit the value 'sucesso', leading to a 400 Bad Request when an agreement was registered. Additionally, the debt's `valor_atualizado` was not being updated as expected when a new agreement was created.

---
<a href="https://cursor.com/background-agent?bcId=bc-e451e7c2-c46a-4e3a-a613-dc0f0cfb8021">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e451e7c2-c46a-4e3a-a613-dc0f0cfb8021">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

