### PR TITLE
Fix external complaint registration attachment error

### DIFF
--- a/src/pages/DenunciaPublica.tsx
+++ b/src/pages/DenunciaPublica.tsx
@@ -132,7 +132,7 @@ export default function DenunciaPublica() {
           const path = `${folder}/${Date.now()}_${safeName}`;
           const { data: uploadData, error: uploadError } = await supabase.storage
             .from('denuncia-anexos')
-            .upload(path, file, { cacheControl: '3600', upsert: true });
+            .upload(path, file, { cacheControl: '3600' });
           if (uploadError) throw uploadError;
           anexosPaths.push(uploadData.path);
         }

--- a/src/pages/DenunciasDashboard.tsx
+++ b/src/pages/DenunciasDashboard.tsx
@@ -114,7 +114,7 @@ export default function DenunciasDashboard() {
         const path = `${folder}/${Date.now()}_${safeName}`;
         const { data: uploadData, error: uploadError } = await supabase.storage
           .from('denuncia-anexos')
-          .upload(path, file, { cacheControl: '3600', upsert: true });
+          .upload(path, file, { cacheControl: '3600' });
         if (uploadError) throw uploadError;
         anexosPaths.push(uploadData.path);
       }

--- a/supabase/migrations/20250831120000_create_denuncia_anexos_bucket.sql
+++ b/supabase/migrations/20250831120000_create_denuncia_anexos_bucket.sql
@@ -1,10 +1,12 @@
 -- Create storage bucket for denuncia attachments
-INSERT INTO storage.buckets (id, name, public) VALUES ('denuncia-anexos', 'denuncia-anexos', false);
+INSERT INTO storage.buckets (id, name, public) VALUES ('denuncia-anexos', 'denuncia-anexos', false)
+ON CONFLICT (id) DO NOTHING;
 
 -- Allow anyone (including anonymous) to upload into denuncia-anexos
 CREATE POLICY "Anyone can upload denuncia anexos"
 ON storage.objects 
 FOR INSERT 
+TO anon, authenticated
 WITH CHECK (
   bucket_id = 'denuncia-anexos'
 );


### PR DESCRIPTION
Remove `upsert: true` from attachment uploads and clarify bucket policy to fix external complaint registration errors.

The `upsert: true` option in Supabase storage uploads implicitly requires `UPDATE` permissions, which is not granted to anonymous users. This caused failures when submitting complaints with attachments from external environments. By removing `upsert: true` and explicitly granting `INSERT` permissions to `anon` and `authenticated` roles in the `denuncia-anexos` bucket, we ensure that new attachments can be uploaded successfully without requiring unnecessary `UPDATE` privileges. The bucket remains private, and file access is still controlled via signed URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7a46229-95fd-4456-af73-2c3b18556e6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7a46229-95fd-4456-af73-2c3b18556e6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

