### PR TITLE
Organizar menus em submenu de opções

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -28,18 +28,27 @@ export function AppSidebar() {
     <Logo variant="icon" size="sm" className={className} />
   );
 
+  // Itens principais fora de "Opções"
   const items: Item[] = [
     { title: "Painel", url: "/", icon: MrxIcon as unknown as LucideIcon, show: true },
     { title: "Tarefas", url: "/tarefas", icon: KanbanSquare, show: true },
     { title: "Empresas", url: "/empresas", icon: Building2, show: true },
     { title: "Debto - Cobranças", url: "/debto", icon: DollarSign, show: true },
     { title: "Dashboard Denúncias", url: "/denuncias/dashboard", icon: Shield, show: true },
+  ];
+
+  // Submenus agrupados em "Opções"
+  const optionItems: Item[] = [
     { title: "Log de Atividades", url: "/admin/activity-log", icon: Activity, show: profile?.role === 'superuser' },
     { title: "Dados do Sistema", url: "/admin/system-data", icon: Settings2, show: true },
     { title: "Estrutura", url: "/admin/structure", icon: ListTree, show: true },
     { title: "Usuários", url: "/admin/users", icon: Users, show: true },
     { title: "Documentação", url: "/admin/docs", icon: BookText, show: true },
   ];
+
+  const [optionsOpen, setOptionsOpen] = React.useState(false);
+  const optionsHasActive = optionItems.some((i) => i.show && path === i.url);
+  const optionsVisible = optionItems.some((i) => i.show);
 
   return (
     <Sidebar>
@@ -57,6 +66,39 @@ export function AppSidebar() {
                 }}
               />
             ))}
+
+            {optionsVisible && (
+              <>
+                <SidebarLink
+                  className={(optionsHasActive ? "bg-neutral-200/60 dark:bg-neutral-700/60 rounded-md " : "") + "px-2"}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setOptionsOpen((prev) => !prev);
+                  }}
+                  link={{
+                    label: "Opções",
+                    href: "#",
+                    icon: <Settings2 className="text-neutral-700 dark:text-neutral-200 h-4 w-4 flex-shrink-0" />,
+                  }}
+                />
+
+                {optionsOpen && (
+                  <div className="ml-6 flex flex-col gap-1">
+                    {optionItems.filter((i) => i.show).map((item) => (
+                      <SidebarLink
+                        key={item.title}
+                        className={path === item.url ? "bg-neutral-200/60 dark:bg-neutral-700/60 rounded-md px-2" : "px-2"}
+                        link={{
+                          label: item.title,
+                          href: item.url,
+                          icon: <item.icon className="text-neutral-700 dark:text-neutral-200 h-4 w-4 flex-shrink-0" />,
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
           </div>
         </div>
         <div className="mb-2">


### PR DESCRIPTION
Grouped four existing sidebar menu items under a new "Opções" collapsible submenu.

---
<a href="https://cursor.com/background-agent?bcId=bc-8031a237-aabb-4fed-8cdd-940523936272">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8031a237-aabb-4fed-8cdd-940523936272">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

