### PR TITLE
Archive task card on close

### DIFF
--- a/src/hooks/useTarefasDataNew.ts
+++ b/src/hooks/useTarefasDataNew.ts
@@ -36,6 +36,7 @@ export function useTarefasData() {
       const { data: tarefasData, error: tarefasError } = await supabase
         .from('tarefas')
         .select('*')
+        .eq('is_archived', false)
         .order('ordem_na_coluna', { ascending: true })
         .order('created_at', { ascending: false });
 

--- a/src/pages/TarefasDashboard.tsx
+++ b/src/pages/TarefasDashboard.tsx
@@ -177,6 +177,9 @@ export default function TarefasDashboard() {
                 onTaskCreate={handleTaskCreateFromColumn}
                 onTaskDelete={deleteTarefa}
                 onTaskClick={handleTaskClick}
+                onTaskClose={(task) => {
+                  void updateTarefa(task.id, { is_archived: true, archived_at: new Date().toISOString() });
+                }}
                 loading={loading}
               />
             </div>
@@ -214,6 +217,9 @@ export default function TarefasDashboard() {
                   onTaskCreate={handleTaskCreateFromColumn}
                   onTaskDelete={deleteTarefa}
                   onTaskClick={handleTaskClick}
+                  onTaskClose={(task) => {
+                    void updateTarefa(task.id, { is_archived: true, archived_at: new Date().toISOString() });
+                  }}
                   loading={loading}
                 />
               </div>

--- a/src/types/tarefas.ts
+++ b/src/types/tarefas.ts
@@ -12,6 +12,9 @@ export interface Tarefa {
   modulo_origem: TaskModule;
   empresa_id?: string;
   responsavel_id?: string;
+  // Archive control
+  is_archived?: boolean;
+  archived_at?: string;
   // Boards/Columns (opcional)
   board_id?: string;
   column_id?: string;

--- a/supabase/migrations/20250915091500_add_task_archive.sql
+++ b/supabase/migrations/20250915091500_add_task_archive.sql
@@ -1,0 +1,8 @@
+-- Add archive fields to tarefas
+ALTER TABLE public.tarefas
+  ADD COLUMN IF NOT EXISTS is_archived BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP WITH TIME ZONE NULL;
+
+-- Index to filter archived quickly
+CREATE INDEX IF NOT EXISTS idx_tarefas_is_archived ON public.tarefas(is_archived);
+


### PR DESCRIPTION
Implement task archiving for cards closed in `/tarefas` instead of marking them as complete.

---
<a href="https://cursor.com/background-agent?bcId=bc-abd18926-d261-4b63-bc02-672bf1b4e6dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-abd18926-d261-4b63-bc02-672bf1b4e6dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

