### PR TITLE
Criar menu de navegação e organizar páginas

### DIFF
--- a/src/components/OptionsMenu.tsx
+++ b/src/components/OptionsMenu.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { useAuth } from "@/context/AuthContext";
+import {
+  Settings2,
+  Activity,
+  ListTree,
+  Users,
+  BookText,
+} from "lucide-react";
+
+export function OptionsMenu() {
+  const { profile } = useAuth();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="gap-2">
+          <Settings2 className="h-4 w-4" />
+          <span>Opções</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Administração</DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <Link to="/admin/system-data" className="flex items-center gap-2">
+            <Settings2 className="h-4 w-4" />
+            <span>Dados do Sistema</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/admin/structure" className="flex items-center gap-2">
+            <ListTree className="h-4 w-4" />
+            <span>Estrutura</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/admin/users" className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span>Usuários</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/admin/docs" className="flex items-center gap-2">
+            <BookText className="h-4 w-4" />
+            <span>Documentação</span>
+          </Link>
+        </DropdownMenuItem>
+        {profile?.role === "superuser" && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link
+                to="/admin/activity-log"
+                className="flex items-center gap-2"
+              >
+                <Activity className="h-4 w-4" />
+                <span>Log de Atividades</span>
+              </Link>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default OptionsMenu;
+

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -35,11 +35,7 @@ export function AppSidebar() {
     { title: "Empresas", url: "/empresas", icon: Building2, show: true },
     { title: "Debto - Cobranças", url: "/debto", icon: DollarSign, show: true },
     { title: "Dashboard Denúncias", url: "/denuncias/dashboard", icon: Shield, show: true },
-    { title: "Log de Atividades", url: "/admin/activity-log", icon: Activity, show: profile?.role === 'superuser' },
-    { title: "Dados do Sistema", url: "/admin/system-data", icon: Settings2, show: true },
-    { title: "Estrutura", url: "/admin/structure", icon: ListTree, show: true },
-    { title: "Usuários", url: "/admin/users", icon: Users, show: true },
-    { title: "Documentação", url: "/admin/docs", icon: BookText, show: true },
+    // Itens administrativos movidos para o menu "Opções" no cabeçalho
   ];
 
   return (

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from "react-router-dom";
 import { AppSidebar } from "@/components/app-sidebar";
 import { Logo } from "@/components/ui/logo";
 import { FloatingTaskButton } from "@/components/tarefas/FloatingTaskButton";
+import { OptionsMenu } from "@/components/OptionsMenu";
 import { useTarefasData } from "@/hooks/useTarefasDataNew";
 
 const AppLayout: React.FC = () => {
@@ -57,7 +58,7 @@ const AppLayout: React.FC = () => {
             <Logo className="text-primary" />
           </div>
           <div className="flex items-center gap-3 text-sm">
-            <span className="text-muted-foreground">Sistema Aberto</span>
+            <OptionsMenu />
           </div>
         </header>
         <div className="p-2 md:p-4">


### PR DESCRIPTION
Adds an "Opções" dropdown menu to the header and moves administrative pages into it, decluttering the sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-42422e66-a42d-46bd-8c70-bffcfde11a43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42422e66-a42d-46bd-8c70-bffcfde11a43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

