### PR TITLE
feat: add board edit action and refine task typing

### DIFF
--- a/src/hooks/useTaskBoards.ts
+++ b/src/hooks/useTaskBoards.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import type { Database } from '@/integrations/supabase/types';
 
 export interface TaskBoard {
   id: string;
@@ -254,8 +255,9 @@ export function useTaskBoards(boardId?: string) {
 
   const fetchBoardTasks = async (bId: string) => {
     try {
+      type Tarefa = Database['public']['Tables']['tarefas']['Row'];
       const { data: tasksData, error } = await supabase
-        .from('tarefas')
+        .from<Tarefa>('tarefas')
         .select('*')
         .eq('board_id', bId)
         .order('ordem_na_coluna', { ascending: true })

--- a/src/pages/TarefasBoards.tsx
+++ b/src/pages/TarefasBoards.tsx
@@ -126,7 +126,8 @@ export default function TarefasBoards() {
                 <div className="flex items-center justify-between">
                   <CardTitle className="cursor-pointer" onClick={() => navigate(`/tarefas/quadros/${board.id}`)}>{board.name}</CardTitle>
                   <div className="flex gap-2">
-                    <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); startEditing(board.id, board.name); }}>Editar</Button>
+                    <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); navigate(`/tarefas/quadros/${board.id}`); }}>Editar</Button>
+                    <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); startEditing(board.id, board.name); }}>Renomear</Button>
                     <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); void deleteBoard(board.id); }}>Excluir</Button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add explicit Edit button on board list to open board editor
- type Supabase fetchBoardTasks query using Database types

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a60a3176088333877c9c2ee1749318