### PR TITLE
Handle task archiving and regenerate Supabase types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1312,6 +1312,8 @@ export type Database = {
           divida_id: string | null
           empresa_id: string | null
           id: string
+          is_archived: boolean
+          archived_at: string | null
           modulo_origem: Database["public"]["Enums"]["task_module"]
           ordem_na_coluna: number | null
           prioridade: Database["public"]["Enums"]["task_priority"]
@@ -1333,6 +1335,8 @@ export type Database = {
           divida_id?: string | null
           empresa_id?: string | null
           id?: string
+          is_archived?: boolean
+          archived_at?: string | null
           modulo_origem?: Database["public"]["Enums"]["task_module"]
           ordem_na_coluna?: number | null
           prioridade?: Database["public"]["Enums"]["task_priority"]
@@ -1354,6 +1358,8 @@ export type Database = {
           divida_id?: string | null
           empresa_id?: string | null
           id?: string
+          is_archived?: boolean
+          archived_at?: string | null
           modulo_origem?: Database["public"]["Enums"]["task_module"]
           ordem_na_coluna?: number | null
           prioridade?: Database["public"]["Enums"]["task_priority"]


### PR DESCRIPTION
## Summary
- include `is_archived` and `archived_at` in generated Supabase task types
- gracefully handle missing archive columns and remove archived tasks from state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60b79fe148333910f27021391866a