### PR TITLE
Carregar histórico de colaborador

### DIFF
--- a/src/context/HRContext.tsx
+++ b/src/context/HRContext.tsx
@@ -132,7 +132,12 @@ const convertColaboradorFromSupabase = (colaborador: SupabaseColaborador): Colab
   },
   foto_perfil: colaborador.foto_perfil,
   documentos_arquivos: [],
-  historico: [],
+  historico: (colaborador.historico_colaborador || []).map(h => ({
+    id: h.id,
+    data: h.created_at,
+    observacao: h.observacao,
+    usuario: h.profiles?.full_name || ''
+  })),
   auditoria: {
     created_at: colaborador.created_at,
     updated_at: colaborador.updated_at,

--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -16,6 +16,16 @@ export type Empresa = {
   created_by?: string;
 };
 
+export type HistoricoColaborador = {
+  id: string;
+  observacao: string;
+  created_at: string;
+  created_by: string;
+  profiles?: {
+    full_name: string | null;
+  };
+};
+
 export type Colaborador = {
   id: string;
   nome: string;
@@ -68,6 +78,7 @@ export type Colaborador = {
   created_at: string;
   updated_at: string;
   created_by?: string;
+  historico_colaborador?: HistoricoColaborador[];
 };
 
 export type Denuncia = {
@@ -132,11 +143,11 @@ export const useSupabaseData = () => {
     try {
       const { data, error } = await supabase
         .from('colaboradores')
-        .select('*')
+        .select('*, historico_colaborador(*, profiles:created_by(full_name))')
         .order('nome');
 
       if (error) throw error;
-      setColaboradores(data || []);
+      setColaboradores((data || []) as Colaborador[]);
     } catch (error) {
       console.error('Error fetching colaboradores:', error);
       toast({

--- a/src/lib/historico.ts
+++ b/src/lib/historico.ts
@@ -1,9 +1,10 @@
 import { supabase } from '@/integrations/supabase/client';
-import type { Database } from '@/integrations/supabase/types';
+import type { HistoricoColaborador } from '@/types/hr';
 
-export type HistoricoColaboradorRow = Database['public']['Tables']['historico_colaborador']['Row'];
-
-export async function saveObservacao(colaboradorId: string, observacao: string): Promise<HistoricoColaboradorRow> {
+export async function saveObservacao(
+  colaboradorId: string,
+  observacao: string
+): Promise<HistoricoColaborador> {
   const { data: userData, error: authError } = await supabase.auth.getUser();
   if (authError) {
     throw new Error(authError.message || 'Falha ao obter usuário autenticado');
@@ -20,13 +21,18 @@ export async function saveObservacao(colaboradorId: string, observacao: string):
       observacao,
       created_by: user.id
     })
-    .select()
+    .select('*, profiles:created_by(full_name)')
     .single();
 
   if (error) {
     throw new Error(error.message);
   }
 
-  return data;
+  return {
+    id: data.id,
+    data: data.created_at,
+    observacao: data.observacao,
+    usuario: data.profiles?.full_name || ''
+  };
 }
 


### PR DESCRIPTION
## Summary
- Buscar colaboradores já trazendo histórico com autor
- Mapear entradas de histórico para o formato usado na interface
- Retornar dados do autor ao salvar nova observação

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a60c0d1ce883339cd39ebea20aa80e